### PR TITLE
feat: add discourse_create_user MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ Built‑in tools (always present unless noted):
   - Query language (succinct): key:value tokens separated by spaces; category/categories (comma = OR, `=category` = without subcats, `-` prefix = exclude); tag/tags (comma = OR, `+` = AND) and tag_group; status:(open|closed|archived|listed|unlisted|public); personal `in:` (bookmarked|watching|tracking|muted|pinned); dates: created/activity/latest-post-(before|after) with `YYYY-MM-DD` or relative days `N`; numeric: likes[-op]-(min|max), posts-(min|max), posters-(min|max), views-(min|max); order: activity|created|latest-post|likes|likes-op|posters|title|views|category with optional `-asc`; free text terms are matched.
 - `discourse_create_post` (only when writes enabled; see Write safety)
   - Input: `{ topic_id: number; raw: string (≤ 30k chars) }`
+- `discourse_create_user` (only when writes enabled; see Write safety)
+  - Input: `{ username: string (1-20 chars); email: string; name: string; password: string; active?: boolean; approved?: boolean }`
 
 Notes:
 - Outputs are human‑readable first. Where applicable, a compact JSON is embedded in fenced code blocks to ease structured extraction by agents.

--- a/src/tools/builtin/create_user.ts
+++ b/src/tools/builtin/create_user.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+import type { RegisterFn } from "../types.js";
+
+export const registerCreateUser: RegisterFn = (server, ctx, opts) => {
+  if (!opts?.allowWrites) return;
+
+  const schema = z.object({
+    username: z.string().min(1).max(20),
+    email: z.string().email(),
+    name: z.string().min(1).max(255),
+    password: z.string().min(10).max(200),
+    active: z.boolean().optional().default(true),
+    approved: z.boolean().optional().default(true),
+  });
+
+  server.registerTool(
+    "discourse_create_user",
+    {
+      title: "Create User",
+      description: "Create a new user account in Discourse.",
+      inputSchema: schema.shape,
+    },
+    async (args, _extra: any) => {
+      try {
+        const { client } = ctx.siteState.ensureSelectedSite();
+        
+        const userData = {
+          username: args.username,
+          email: args.email,
+          name: args.name,
+          password: args.password,
+          active: args.active,
+          approved: args.approved,
+        };
+
+        const response = await client.post("/users.json", userData) as any;
+        
+        if (response.success) {
+          return {
+            content: [{
+              type: "text",
+              text: `User created successfully!\n` +
+                    `Username: ${args.username}\n` +
+                    `Name: ${args.name}\n` +
+                    `Email: ${args.email}\n` +
+                    `Status: ${response.active ? 'Active' : 'Inactive'}\n` +
+                    `Message: ${response.message || 'Account created'}`
+            }]
+          };
+        } else {
+          return {
+            content: [{
+              type: "text",
+              text: `Failed to create user: ${response.message || 'Unknown error'}`
+            }],
+            isError: true
+          };
+        }
+      } catch (e: any) {
+        return {
+          content: [{
+            type: "text",
+            text: `Failed to create user: ${e?.message || String(e)}`
+          }],
+          isError: true
+        };
+      }
+    }
+  );
+};

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -10,6 +10,7 @@ import { registerGetUser } from "./builtin/get_user.js";
 import { registerCreatePost } from "./builtin/create_post.js";
 import { registerSelectSite } from "./builtin/select_site.js";
 import { registerFilterTopics } from "./builtin/filter_topics.js";
+import { registerCreateUser } from "./builtin/create_user.js";
 
 export type ToolsMode = "auto" | "discourse_api_only" | "tool_exec_api";
 
@@ -42,4 +43,5 @@ export async function registerAllTools(
   registerGetUser(server, ctx, { allowWrites: false });
   registerFilterTopics(server, ctx, { allowWrites: false });
   registerCreatePost(server, ctx, { allowWrites: opts.allowWrites });
+  registerCreateUser(server, ctx, { allowWrites: opts.allowWrites });
 }


### PR DESCRIPTION
- Add new tool for creating users in Discourse
- Supports username, email, name, password, active, and approved fields
- Only available when writes are enabled
- Update README with tool documentation