### PR TITLE
feat: add discourse_create_category MCP tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@
 - Supported auth:
   - **None** (read-only public data)
   - Per-site overrides via `--auth_pairs`, e.g. `[{"site":"https://example.com","api_key":"...","api_username":"system"}]`.
-- **Writes are disabled by default**. `discourse.create_post` is only registered when all are true:
+- **Writes are disabled by default**. `discourse.create_post` and `discourse.create_category` are only registered when all are true:
   - `--allow_writes` AND not `--read_only` AND a matching `auth_pairs` entry exists for the selected site.
 - Secrets are never logged; config is redacted before logging.
 
@@ -44,11 +44,14 @@
   - **Output**: Paginated topic list with titles and URLs; appends a JSON footer `{ page, per_page, results: [{ id, url, title }], next_url? }`.
   - Query language: key:value tokens separated by spaces; category/categories (comma = OR, `=category` = without subcats, `-` exclude); tag/tags (comma = OR, `+` = AND) and tag_group; status:(open|closed|archived|listed|unlisted|public); personal `in:` (bookmarked|watching|tracking|muted|pinned); dates created/activity/latest-post-(before|after) as `YYYY-MM-DD` or `N` days; numeric likes[-op]-(min|max), posts-(min|max), posters-(min|max), views-(min|max); `order:` with optional `-asc`; free text terms allowed.
 - **discourse_create_post** (conditionally available; see permissions)
- - **discourse_select_site** (hidden when `--site` is provided)
-   - **Input**: `{ site: string }`
-   - **Output**: Confirms selection; validates via `/about.json`. Triggers remote tool discovery when enabled.
   - **Input**: `{ topic_id: number; raw: string (≤ 30k chars) }`
   - **Output**: Link to created post/topic. Includes a simple 1 req/sec rate limit.
+- **discourse_create_category** (conditionally available; see permissions)
+  - **Input**: `{ name: string; color?: hex; text_color?: hex; parent_category_id?: number; description?: string }`
+  - **Output**: Link to created category. Includes a simple 1 req/sec rate limit.
+- **discourse_select_site** (hidden when `--site` is provided)
+  - **Input**: `{ site: string }`
+  - **Output**: Confirms selection; validates via `/about.json`. Triggers remote tool discovery when enabled.
 
 ### Remote Tool Execution API (optional)
 - If the target Discourse site exposes an MCP-compatible Tool Execution API:
@@ -79,7 +82,7 @@
 
 ### Errors & rate limits
 - Tool failures return `isError: true` with human-readable messages.
-- `discourse.create_post` enforces ~1 request/second to avoid flooding.
+- `discourse.create_post` and `discourse.create_category` enforce ~1 request/second to avoid flooding.
 
 ### Source map
 - MCP server and CLI: `src/index.ts`

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ The server registers tools under the MCP server name `@discourse/mcp`. Choose a 
 
 - **Write safety**
   - Writes are disabled by default.
-  - The tool `discourse.create_post` is only registered when all are true:
+  - The tools `discourse.create_post` and `discourse.create_category` are only registered when all are true:
     - `--allow_writes` AND not `--read_only` AND some auth is configured (either default flags or a matching `auth_pairs` entry).
-  - A ~1 req/sec rate limit is enforced for `create_post`.
+  - A ~1 req/sec rate limit is enforced for `create_post` and `create_category`.
 
 - **Flags & defaults**
   - `--read_only` (default: true)
@@ -130,6 +130,8 @@ Built‑in tools (always present unless noted):
   - Query language (succinct): key:value tokens separated by spaces; category/categories (comma = OR, `=category` = without subcats, `-` prefix = exclude); tag/tags (comma = OR, `+` = AND) and tag_group; status:(open|closed|archived|listed|unlisted|public); personal `in:` (bookmarked|watching|tracking|muted|pinned); dates: created/activity/latest-post-(before|after) with `YYYY-MM-DD` or relative days `N`; numeric: likes[-op]-(min|max), posts-(min|max), posters-(min|max), views-(min|max); order: activity|created|latest-post|likes|likes-op|posters|title|views|category with optional `-asc`; free text terms are matched.
 - `discourse_create_post` (only when writes enabled; see Write safety)
   - Input: `{ topic_id: number; raw: string (≤ 30k chars) }`
+- `discourse_create_category` (only when writes enabled; see Write safety)
+  - Input: `{ name: string; color?: hex; text_color?: hex; parent_category_id?: number; description?: string }`
 
 Notes:
 - Outputs are human‑readable first. Where applicable, a compact JSON is embedded in fenced code blocks to ease structured extraction by agents.
@@ -187,6 +189,13 @@ npx -y @discourse/mcp@latest --site https://try.discourse.org
 - Create a post (writes enabled):
 ```bash
 npx -y @discourse/mcp@latest --allow_writes --read_only=false --auth_pairs '[{"site":"https://try.discourse.org","api_key":"'$DISCOURSE_API_KEY'","api_username":"system"}]'
+```
+
+- Create a category (writes enabled):
+```bash
+npx -y @discourse/mcp@latest --allow_writes --read_only=false --auth_pairs '[{"site":"https://try.discourse.org","api_key":"'$DISCOURSE_API_KEY'","api_username":"system"}]'
+# In your MCP client, call discourse_create_category with for example:
+# { "name": "AI Research", "color": "0088CC", "text_color": "FFFFFF", "description": "Discussions about AI research" }
 ```
 
 ## FAQ

--- a/src/test/tools.test.ts
+++ b/src/test/tools.test.ts
@@ -18,6 +18,25 @@ function createFakeTransport() {
 test('registers built-in tools', async () => {
   const logger = new Logger('silent');
   const siteState = new SiteState({ logger, timeoutMs: 5000, defaultAuth: { type: 'none' } });
+
+test('registers write-enabled tools when allowWrites=true', async () => {
+  const logger = new Logger('silent');
+  const siteState = new SiteState({ logger, timeoutMs: 5000, defaultAuth: { type: 'none' } });
+
+  // Minimal fake server to capture tool registrations
+  const tools: Record<string, { handler: Function }> = {};
+  const fakeServer: any = {
+    registerTool(name: string, _meta: any, handler: Function) {
+      tools[name] = { handler };
+    },
+  };
+
+  await registerAllTools(fakeServer, siteState, logger, { allowWrites: true, toolsMode: 'discourse_api_only' } as any);
+
+  // When writes are enabled, both create tools should be registered
+  assert.ok('discourse_create_post' in tools);
+  assert.ok('discourse_create_category' in tools);
+});
   const server = new McpServer({ name: 'test', version: '0.0.0' }, { capabilities: { tools: { listChanged: false } } });
 
   await registerAllTools(server as any, siteState, logger, { allowWrites: false, toolsMode: 'discourse_api_only' });

--- a/src/tools/builtin/create_category.ts
+++ b/src/tools/builtin/create_category.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+import type { RegisterFn } from "../types.js";
+
+let lastCategoryAt = 0;
+
+export const registerCreateCategory: RegisterFn = (server, ctx, opts) => {
+  if (!opts.allowWrites) return; // disabled by default
+
+  const schema = z.object({
+    name: z.string().min(1).max(100),
+    color: z.string().regex(/^[0-9a-fA-F]{6}$/).optional(),
+    text_color: z.string().regex(/^[0-9a-fA-F]{6}$/).optional(),
+    parent_category_id: z.number().int().positive().optional(),
+    description: z.string().min(1).max(10000).optional(),
+  });
+
+  server.registerTool(
+    "discourse_create_category",
+    {
+      title: "Create Category",
+      description: "Create a new category.",
+      inputSchema: schema.shape,
+    },
+    async (input: any, _extra: any) => {
+      const { name, color, text_color, parent_category_id, description } = schema.parse(input);
+
+      // Simple 1 req/sec rate limit
+      const now = Date.now();
+      if (now - lastCategoryAt < 1000) {
+        const wait = 1000 - (now - lastCategoryAt);
+        await new Promise((r) => setTimeout(r, wait));
+      }
+      lastCategoryAt = Date.now();
+
+      try {
+        const { base, client } = ctx.siteState.ensureSelectedSite();
+
+        const payload: any = { name };
+        if (color) payload.color = color;
+        if (text_color) payload.text_color = text_color;
+        if (parent_category_id) payload.parent_category_id = parent_category_id;
+        if (description) payload.description = description;
+
+        const data: any = await client.post(`/categories.json`, payload);
+        const category = data?.category || data;
+
+        const id = category?.id;
+        const slug = category?.slug || (category?.name ? String(category.name).toLowerCase().replace(/\s+/g, "-") : undefined);
+        const title = category?.name || name;
+
+        const link = id && slug ? `${base}/c/${slug}/${id}` : `${base}/categories`;
+        return { content: [{ type: "text", text: `Created category "${title}": ${link}` }] };
+      } catch (e: any) {
+        return { content: [{ type: "text", text: `Failed to create category: ${e?.message || String(e)}` }], isError: true };
+      }
+    }
+  );
+};

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -8,6 +8,7 @@ import { registerListCategories } from "./builtin/list_categories.js";
 import { registerListTags } from "./builtin/list_tags.js";
 import { registerGetUser } from "./builtin/get_user.js";
 import { registerCreatePost } from "./builtin/create_post.js";
+import { registerCreateCategory } from "./builtin/create_category.js";
 import { registerSelectSite } from "./builtin/select_site.js";
 import { registerFilterTopics } from "./builtin/filter_topics.js";
 
@@ -42,4 +43,5 @@ export async function registerAllTools(
   registerGetUser(server, ctx, { allowWrites: false });
   registerFilterTopics(server, ctx, { allowWrites: false });
   registerCreatePost(server, ctx, { allowWrites: opts.allowWrites });
+  registerCreateCategory(server, ctx, { allowWrites: opts.allowWrites });
 }


### PR DESCRIPTION
- Implement src/tools/builtin/create_category.ts 
- Register tool in src/tools/registry.ts
- Document in README.md and AGENTS.md
- Add usage example to README.md
