### PR TITLE
Add `discourse_create_topic` Tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@
 - Supported auth:
   - **None** (read-only public data)
   - Per-site overrides via `--auth_pairs`, e.g. `[{"site":"https://example.com","api_key":"...","api_username":"system"}]`.
-- **Writes are disabled by default**. `discourse.create_post` and `discourse.create_category` are only registered when all are true:
+- **Writes are disabled by default**. Write tools (`discourse_create_post`, `discourse_create_topic`, `discourse_create_category`, `discourse_create_user`) are only registered when all are true:
   - `--allow_writes` AND not `--read_only` AND a matching `auth_pairs` entry exists for the selected site.
 - Secrets are never logged; config is redacted before logging.
 
@@ -46,6 +46,9 @@
 - **discourse_create_post** (conditionally available; see permissions)
   - **Input**: `{ topic_id: number; raw: string (≤ 30k chars) }`
   - **Output**: Link to created post/topic. Includes a simple 1 req/sec rate limit.
+- **discourse_create_topic** (conditionally available; see permissions)
+  - **Input**: `{ title: string; raw: string (≤ 30k chars); category_id?: number; tags?: string[] }`
+  - **Output**: Link to created topic. Includes a simple 1 req/sec rate limit.
 - **discourse_create_category** (conditionally available; see permissions)
   - **Input**: `{ name: string; color?: hex; text_color?: hex; parent_category_id?: number; description?: string }`
   - **Output**: Link to created category. Includes a simple 1 req/sec rate limit.

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ The server registers tools under the MCP server name `@discourse/mcp`. Choose a 
 
 - **Write safety**
   - Writes are disabled by default.
-  - The tools `discourse.create_post` and `discourse.create_category` are only registered when all are true:
+  - The tools `discourse_create_post`, `discourse_create_topic`, `discourse_create_category`, and `discourse_create_user` are only registered when all are true:
     - `--allow_writes` AND not `--read_only` AND some auth is configured (either default flags or a matching `auth_pairs` entry).
-  - A ~1 req/sec rate limit is enforced for `create_post` and `create_category`.
+  - A ~1 req/sec rate limit is enforced for write actions.
 
 - **Flags & defaults**
   - `--read_only` (default: true)
@@ -131,6 +131,9 @@ Built‑in tools (always present unless noted):
 - `discourse_create_post` (only when writes enabled; see Write safety)
   - Input: `{ topic_id: number; raw: string (≤ 30k chars) }`
 
+- `discourse_create_topic` (only when writes enabled; see Write safety)
+  - Input: `{ title: string; raw: string (≤ 30k chars); category_id?: number; tags?: string[] }`
+
  - `discourse_create_user` (only when writes enabled; see Write safety)
  - Input: `{ username: string (1-20 chars); email: string; name: string; password: string; active?: boolean; approved?: boolean }`
 
@@ -201,6 +204,13 @@ npx -y @discourse/mcp@latest --allow_writes --read_only=false --auth_pairs '[{"s
 npx -y @discourse/mcp@latest --allow_writes --read_only=false --auth_pairs '[{"site":"https://try.discourse.org","api_key":"'$DISCOURSE_API_KEY'","api_username":"system"}]'
 # In your MCP client, call discourse_create_category with for example:
 # { "name": "AI Research", "color": "0088CC", "text_color": "FFFFFF", "description": "Discussions about AI research" }
+```
+
+- Create a topic (writes enabled):
+```bash
+npx -y @discourse/mcp@latest --allow_writes --read_only=false --auth_pairs '[{"site":"https://try.discourse.org","api_key":"'$DISCOURSE_API_KEY'","api_username":"system"}]'
+# In your MCP client, call discourse_create_topic, for example:
+# { "title": "Agentic workflows", "raw": "Let’s discuss agent workflows.", "category_id": 1, "tags": ["ai","agents"] }
 ```
 
 ## FAQ

--- a/src/tools/builtin/create_topic.ts
+++ b/src/tools/builtin/create_topic.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+import type { RegisterFn } from "../types.js";
+
+let lastTopicAt = 0;
+
+export const registerCreateTopic: RegisterFn = (server, ctx, opts) => {
+  if (!opts.allowWrites) return; // disabled by default
+
+  const schema = z.object({
+    title: z.string().min(1).max(300),
+    raw: z.string().min(1).max(30000),
+    category_id: z.number().int().positive().optional(),
+    tags: z.array(z.string().min(1).max(100)).max(10).optional(),
+  });
+
+  server.registerTool(
+    "discourse_create_topic",
+    {
+      title: "Create Topic",
+      description: "Create a new topic with the given title and first post.",
+      inputSchema: schema.shape,
+    },
+    async (input: any, _extra: any) => {
+      const { title, raw, category_id, tags } = schema.parse(input);
+
+      // Simple 1 req/sec rate limit
+      const now = Date.now();
+      if (now - lastTopicAt < 1000) {
+        const wait = 1000 - (now - lastTopicAt);
+        await new Promise((r) => setTimeout(r, wait));
+      }
+      lastTopicAt = Date.now();
+
+      try {
+        const { base, client } = ctx.siteState.ensureSelectedSite();
+
+        const payload: any = { title, raw };
+        if (typeof category_id === "number") payload.category = category_id;
+        if (Array.isArray(tags) && tags.length > 0) payload.tags = tags;
+
+        const data: any = await client.post(`/posts.json`, payload);
+
+        const topicId = data?.topic_id || data?.topicId || data?.topic?.id;
+        const slug = data?.topic_slug || data?.topic?.slug;
+        const postNumber = data?.post_number || data?.post?.post_number || 1;
+        const titleOut = data?.topic_title || data?.title || title;
+
+        const link = topicId
+          ? slug
+            ? `${base}/t/${slug}/${topicId}`
+            : `${base}/t/${topicId}/${postNumber}`
+          : `${base}/latest`;
+
+        return { content: [{ type: "text", text: `Created topic "${titleOut}": ${link}` }] };
+      } catch (e: any) {
+        return { content: [{ type: "text", text: `Failed to create topic: ${e?.message || String(e)}` }], isError: true };
+      }
+    }
+  );
+};
+
+

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -9,6 +9,7 @@ import { registerListTags } from "./builtin/list_tags.js";
 import { registerGetUser } from "./builtin/get_user.js";
 import { registerCreatePost } from "./builtin/create_post.js";
 import { registerCreateCategory } from "./builtin/create_category.js";
+import { registerCreateTopic } from "./builtin/create_topic.js";
 import { registerSelectSite } from "./builtin/select_site.js";
 import { registerFilterTopics } from "./builtin/filter_topics.js";
 import { registerCreateUser } from "./builtin/create_user.js";
@@ -46,4 +47,5 @@ export async function registerAllTools(
   registerCreatePost(server, ctx, { allowWrites: opts.allowWrites });
   registerCreateUser(server, ctx, { allowWrites: opts.allowWrites });
   registerCreateCategory(server, ctx, { allowWrites: opts.allowWrites });
+  registerCreateTopic(server, ctx, { allowWrites: opts.allowWrites });
 }


### PR DESCRIPTION
- Introduces discourse_create_topic to create topics (title, raw, category_id?, tags?).
- Motivation: building an agent with this MCP, creating topics wasn’t easy; this explicit tool call is easier for LLMs to identify.
- Write-gated, 1 req/sec rate limit, registered in registry, docs updated.