### PR TITLE
fix: correct filter_topics pagination to be 0-based

### DIFF
--- a/scripts/validate-filter.mjs
+++ b/scripts/validate-filter.mjs
@@ -19,7 +19,7 @@ async function main() {
   if (selectRes?.isError) throw new Error('select_site failed');
 
   const filter = 'created-after:7 order:likes';
-  const res = await tools['discourse_filter_topics'].handler({ filter, page: 1, per_page: 5 }, {});
+  const res = await tools['discourse_filter_topics'].handler({ filter, page: 0, per_page: 5 }, {});
   const text = String(res?.content?.[0]?.text || '');
   console.log(text);
 }


### PR DESCRIPTION
The Discourse /filter.json endpoint uses 0-based pagination, so the
tool should accept page: 0 as the first page rather than converting
from 1-based. Updated schema validation, default value, and description
to reflect this. Also updated the validation script to use page: 0.
