### PR TITLE
feat: add optional HTTP transport support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 Changelog
+### [0.1.7](https://github.com/SamSaffron/discourse-mcp/compare/v0.1.6...v0.1.7) (2025-10-17)
+
+#### Features
+
+* add optional HTTP transport support via --transport flag
+* implement Streamable HTTP transport (stateless mode) as alternative to stdio
+* add --port flag for configuring HTTP server port (default: 3000)
+* include health check endpoint at /health for HTTP mode
+
 ### [0.1.6](https://github.com/SamSaffron/discourse-mcp/compare/v0.1.5...v0.1.6) (2025-10-16)
 
 #### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ The server registers tools under the MCP server name `@discourse/mcp`. Choose a 
   - `--site <url>`: Tether MCP to a single site and hide `discourse_select_site`.
   - `--default-search <prefix>`: Unconditionally prefix every search query (e.g., `tag:ai order:latest-post`).
   - `--max-read-length <number>`: Maximum characters returned for post content (default 50000). Applies to `discourse_read_post` and per-post content in `discourse_read_topic`. The tools prefer `raw` content by requesting `include_raw=true`.
+  - `--transport <stdio|http>` (default: stdio): Transport type. Use `stdio` for standard input/output (default), or `http` for Streamable HTTP transport (stateless mode with JSON responses).
+  - `--port <number>` (default: 3000): Port to listen on when using HTTP transport.
   - `--cache_dir <path>` (reserved)
   - `--profile <path.json>` (see below)
 
@@ -82,11 +84,11 @@ The server registers tools under the MCP server name `@discourse/mcp`. Choose a 
   "allow_writes": true,
   "log_level": "info",
   "tools_mode": "auto",
-  "site": "https://try.discourse.org"
-  ,
-  "default_search": "tag:ai order:latest-post"
-  ,
-  "max_read_length": 50000
+  "site": "https://try.discourse.org",
+  "default_search": "tag:ai order:latest-post",
+  "max_read_length": 50000,
+  "transport": "stdio",
+  "port": 3000
 }
 ```
 Run with:
@@ -210,7 +212,15 @@ npx -y @discourse/mcp@latest --allow_writes --read_only=false --auth_pairs '[{"s
 ```bash
 npx -y @discourse/mcp@latest --allow_writes --read_only=false --auth_pairs '[{"site":"https://try.discourse.org","api_key":"'$DISCOURSE_API_KEY'","api_username":"system"}]'
 # In your MCP client, call discourse_create_topic, for example:
-# { "title": "Agentic workflows", "raw": "Let’s discuss agent workflows.", "category_id": 1, "tags": ["ai","agents"] }
+# { "title": "Agentic workflows", "raw": "Let's discuss agent workflows.", "category_id": 1, "tags": ["ai","agents"] }
+```
+
+- Run with HTTP transport (on port 3000):
+```bash
+npx -y @discourse/mcp@latest --transport http --port 3000 --site https://try.discourse.org
+# Server will start on http://localhost:3000
+# Health check: http://localhost:3000/health
+# MCP endpoint: http://localhost:3000/mcp
 ```
 
 ## FAQ

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discourse/mcp",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Discourse MCP CLI server (stdio) exposing Discourse tools via MCP",
   "private": false,
   "type": "module",

--- a/src/test/transport.test.ts
+++ b/src/test/transport.test.ts
@@ -1,0 +1,141 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Helper to get a free port
+async function getFreePort(): Promise<number> {
+  return 3000 + Math.floor(Math.random() * 1000);
+}
+
+// Helper to wait for server to be ready
+async function waitForServer(port: number, maxAttempts = 10): Promise<boolean> {
+  for (let i = 0; i < maxAttempts; i++) {
+    try {
+      const response = await fetch(`http://localhost:${port}/health`);
+      if (response.ok) return true;
+    } catch {
+      // Server not ready yet
+    }
+    await new Promise(resolve => setTimeout(resolve, 500));
+  }
+  return false;
+}
+
+test('HTTP transport starts on specified port', async () => {
+  const port = await getFreePort();
+  const indexPath = path.resolve(__dirname, '../../dist/index.js');
+
+  const serverProcess = spawn('node', [
+    indexPath,
+    '--transport', 'http',
+    '--port', String(port),
+    '--log_level', 'silent'
+  ], {
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+
+  try {
+    const ready = await waitForServer(port);
+    assert.ok(ready, 'Server should start successfully');
+  } finally {
+    serverProcess.kill('SIGTERM');
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+});
+
+test('HTTP transport health endpoint returns ok', async () => {
+  const port = await getFreePort();
+  const indexPath = path.resolve(__dirname, '../../dist/index.js');
+
+  const serverProcess = spawn('node', [
+    indexPath,
+    '--transport', 'http',
+    '--port', String(port),
+    '--log_level', 'silent'
+  ], {
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+
+  try {
+    const ready = await waitForServer(port);
+    assert.ok(ready, 'Server should start');
+
+    const response = await fetch(`http://localhost:${port}/health`);
+    assert.equal(response.status, 200);
+
+    const data = await response.json();
+    assert.deepEqual(data, { status: 'ok' });
+  } finally {
+    serverProcess.kill('SIGTERM');
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+});
+
+test('stdio transport is the default', async () => {
+  const indexPath = path.resolve(__dirname, '../../dist/index.js');
+
+  // Start with no transport flag - should use stdio
+  const serverProcess = spawn('node', [
+    indexPath,
+    '--log_level', 'silent'
+  ], {
+    stdio: ['pipe', 'pipe', 'pipe']
+  });
+
+  // Give it a moment to potentially start HTTP server (which it shouldn't)
+  await new Promise(resolve => setTimeout(resolve, 1000));
+
+  // Try to connect to default HTTP port - should fail
+  try {
+    await fetch('http://localhost:3000/health', { signal: AbortSignal.timeout(500) });
+    assert.fail('Should not have HTTP server running in stdio mode');
+  } catch (error: any) {
+    // Expected - no HTTP server should be running
+    assert.ok(error.name === 'AbortError' || error.cause?.code === 'ECONNREFUSED');
+  } finally {
+    serverProcess.kill('SIGTERM');
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+});
+
+test('HTTP transport gracefully handles shutdown', async () => {
+  const port = await getFreePort();
+  const indexPath = path.resolve(__dirname, '../../dist/index.js');
+
+  const serverProcess = spawn('node', [
+    indexPath,
+    '--transport', 'http',
+    '--port', String(port),
+    '--log_level', 'silent'
+  ], {
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+
+  try {
+    const ready = await waitForServer(port);
+    assert.ok(ready, 'Server should start');
+
+    // Send SIGTERM
+    serverProcess.kill('SIGTERM');
+
+    // Wait for graceful shutdown
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    // Server should be down
+    try {
+      await fetch(`http://localhost:${port}/health`, { signal: AbortSignal.timeout(500) });
+      assert.fail('Server should be shut down');
+    } catch (error: any) {
+      // Expected
+      assert.ok(error.name === 'AbortError' || error.cause?.code === 'ECONNREFUSED');
+    }
+  } finally {
+    serverProcess.kill('SIGKILL'); // Ensure cleanup
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+});


### PR DESCRIPTION
## Summary
Add support for running the MCP server over HTTP using Streamable HTTP transport as an alternative to stdio. This enables deployment scenarios where HTTP-based communication is preferred.

## Changes
- Add `--transport` flag (stdio|http) to switch between transport modes
- Add `--port` flag to configure HTTP server port (default: 3000)
- Implement `StreamableHTTPServerTransport` in stateless mode with JSON responses
- Add `/health` endpoint for monitoring HTTP server status
- Add `/mcp` endpoint for MCP communication
- Include comprehensive tests for HTTP transport functionality
- Update documentation with HTTP transport usage examples

## Test plan
- [x] Build succeeds without errors
- [x] All existing tests continue to pass (stdio transport)
- [x] HTTP transport starts successfully on specified port
- [x] Health check endpoint returns expected response
- [x] Stdio remains the default (backward compatible)
- [x] HTTP server handles graceful shutdown

## Backward Compatibility
The default behavior remains unchanged (stdio transport), ensuring full backward compatibility with existing deployments.