### PR TITLE
feat: add discourse_list_user_posts tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 Changelog
-### [0.1.9](https://github.com/SamSaffron/discourse-mcp/compare/v0.1.8...v0.1.9) (2025-10-20)
+### [0.1.9](https://github.com/discourse/discourse-mcp/compare/v0.1.8...v0.1.9) (2025-10-20)
 
 #### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 Changelog
+### [0.1.9](https://github.com/SamSaffron/discourse-mcp/compare/v0.1.8...v0.1.9) (2025-10-20)
+
+#### Features
+
+* add discourse_list_user_posts tool to fetch user posts and replies
+* support pagination with page parameter (30 posts per page)
+* include formatted output with topic titles, dates, excerpts, and URLs
+
 ### [0.1.8](https://github.com/SamSaffron/discourse-mcp/compare/v0.1.7...v0.1.8) (2025-10-20)
 
 #### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discourse/mcp",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Discourse MCP CLI server (stdio) exposing Discourse tools via MCP",
   "private": false,
   "type": "module",

--- a/src/tools/builtin/list_user_posts.ts
+++ b/src/tools/builtin/list_user_posts.ts
@@ -1,0 +1,83 @@
+import { z } from "zod";
+import type { RegisterFn } from "../types.js";
+
+export const registerListUserPosts: RegisterFn = (server, ctx) => {
+  const schema = z.object({
+    username: z.string().min(1),
+    page: z.number().int().min(0).optional(),
+  });
+
+  server.registerTool(
+    "discourse_list_user_posts",
+    {
+      title: "List User Posts",
+      description: "Get a list of user posts and replies from a Discourse instance, with the most recent first. Returns 30 posts per page by default. Use the page parameter to paginate (page 0 = offset 0, page 1 = offset 30, etc.).",
+      inputSchema: schema.shape,
+    },
+    async ({ username, page }, _extra: any) => {
+      try {
+        const { base, client } = ctx.siteState.ensureSelectedSite();
+        const offset = (page || 0) * 30;
+
+        // The filter parameter 4,5 corresponds to posts and replies
+        const data = (await client.get(
+          `/user_actions.json?offset=${offset}&username=${encodeURIComponent(username)}&filter=4,5`
+        )) as any;
+
+        const userActions = data?.user_actions || [];
+
+        if (userActions.length === 0) {
+          return {
+            content: [{
+              type: "text",
+              text: page && page > 0
+                ? `No more posts found for @${username} at page ${page}.`
+                : `No posts found for @${username}.`
+            }]
+          };
+        }
+
+        const posts = userActions.map((action: any) => {
+          const excerpt = action.excerpt || "";
+          const truncated = action.truncated ? "..." : "";
+          const date = action.created_at || "";
+          const topicTitle = action.title || "";
+          const topicSlug = action.slug || "";
+          const topicId = action.topic_id || "";
+          const postNumber = action.post_number || "";
+          const categoryId = action.category_id || "";
+
+          const postUrl = `${base}/t/${topicSlug}/${topicId}/${postNumber}`;
+
+          return [
+            `**${topicTitle}**`,
+            `Posted: ${date}`,
+            `Topic: ${postUrl}`,
+            categoryId ? `Category ID: ${categoryId}` : undefined,
+            excerpt ? `\n${excerpt}${truncated}` : undefined,
+          ].filter(Boolean).join("\n");
+        });
+
+        const totalShown = userActions.length;
+        const pageInfo = page && page > 0 ? ` (page ${page})` : "";
+        const header = `Showing ${totalShown} posts for @${username}${pageInfo}:\n\n`;
+        const footer = totalShown === 30 ? `\n\nTo see more posts, use page ${(page || 0) + 1}.` : "";
+
+        return {
+          content: [{
+            type: "text",
+            text: header + posts.join("\n\n---\n\n") + footer
+          }]
+        };
+      } catch (e: any) {
+        return {
+          content: [{
+            type: "text",
+            text: `Failed to get posts for ${username}: ${e?.message || String(e)}`
+          }],
+          isError: true
+        };
+      }
+    }
+  );
+};

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -13,6 +13,7 @@ import { registerCreateTopic } from "./builtin/create_topic.js";
 import { registerSelectSite } from "./builtin/select_site.js";
 import { registerFilterTopics } from "./builtin/filter_topics.js";
 import { registerCreateUser } from "./builtin/create_user.js";
+import { registerListUserPosts } from "./builtin/list_user_posts.js";
 
 export type ToolsMode = "auto" | "discourse_api_only" | "tool_exec_api";
 
@@ -43,6 +44,7 @@ export async function registerAllTools(
   registerListCategories(server, ctx, { allowWrites: false });
   registerListTags(server, ctx, { allowWrites: false });
   registerGetUser(server, ctx, { allowWrites: false });
+  registerListUserPosts(server, ctx, { allowWrites: false });
   registerFilterTopics(server, ctx, { allowWrites: false });
   registerCreatePost(server, ctx, { allowWrites: opts.allowWrites });
   registerCreateUser(server, ctx, { allowWrites: opts.allowWrites });


### PR DESCRIPTION
## Summary
This PR adds a new `discourse_list_user_posts` tool to fetch user posts and replies from Discourse instances.

## Changes
- Added new tool file: `src/tools/builtin/list_user_posts.ts`
- Registered the tool in the tools registry
- Updated CHANGELOG.md with feature details
- Bumped version to 0.1.9

## Features
- Fetches posts via `/user_actions.json` endpoint with `filter=4,5` (posts and replies)
- Supports pagination with `page` parameter (30 posts per page)
- Returns formatted output including:
  - Topic titles and URLs
  - Post dates
  - Post excerpts with truncation indicators
  - Category IDs
  - Helpful pagination hints when more posts are available

## Test plan
- [x] Build succeeds without errors
- [x] All existing tests pass (10/10)
- [x] TypeScript type checking passes
- [x] API endpoint verified working with real data from meta.discourse.org