### PR TITLE
FIX: Use post_number parameter instead of invalid near parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 Changelog
+### [0.1.10](https://github.com/discourse/discourse-mcp/compare/v0.1.9...v0.1.10) (2025-11-11)
+
+#### Bug Fixes
+
+* fix start_post_number parameter in discourse_read_topic - use valid post_number API parameter instead of invalid near parameter
+* fixes bug where start_post_number > 20 would return zero posts due to invalid API parameter being ignored by Discourse
+
 ### [0.1.9](https://github.com/discourse/discourse-mcp/compare/v0.1.8...v0.1.9) (2025-10-20)
 
 #### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discourse/mcp",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Discourse MCP CLI server (stdio) exposing Discourse tools via MCP",
   "private": false,
   "type": "module",

--- a/src/tools/builtin/read_topic.ts
+++ b/src/tools/builtin/read_topic.ts
@@ -32,7 +32,7 @@ export const registerReadTopic: RegisterFn = (server, ctx) => {
         const limit = Number.isFinite(ctx.maxReadLength) ? ctx.maxReadLength : 50000;
         for (let i = 0; i < maxBatches && fetchedPosts.length < post_limit; i++) {
           // Ask for raw content when possible
-          const url = current > 1 ? `/t/${topic_id}.json?near=${current}&include_raw=true` : `/t/${topic_id}.json?include_raw=true`;
+          const url = current > 1 ? `/t/${topic_id}.json?post_number=${current}&include_raw=true` : `/t/${topic_id}.json?include_raw=true`;
           const data = (await client.get(url)) as any;
           if (i === 0) {
             title = data?.title || title;


### PR DESCRIPTION
The `start_post_number` parameter was broken for post numbers > 20. The code was using ?near=${current} which is not a valid Discourse API parameter (only post_number is accepted per topics_controller.rb).

When near was ignored by Discourse, it returned the default first ~20 posts. The client-side filtering in read_topic.ts (lines 44-45) masked this bug for post numbers <= 20, but revealed it for higher numbers where the filter found no matching posts.

Ref: /t/167017