### PR TITLE
DEV: Run `pnpm install` in the `publish` jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,5 +37,6 @@ jobs:
         with:
           node-version: "24"
           cache: pnpm
+      - run: pnpm install
       - name: Publish package
         run: pnpm publish -r

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "prepublishOnly": "pnpm run build",
+    "prepublishOnly": "pnpm build",
     "dev": "node --enable-source-maps dist/index.js",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist",


### PR DESCRIPTION
Fixes the package publishing.

Installing packages is required here because of `prepublishOnly` hook that runs `tsc`.