### PR TITLE
FEATURE: Add Discourse Chat tools to MCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 Changelog
+### [0.1.12](https://github.com/discourse/discourse-mcp/compare/v0.1.11...v0.1.12) (2025-12-03)
+
+#### Features
+
+* add discourse_list_chat_channels tool to list all public chat channels with filtering and pagination
+* add discourse_list_user_chat_channels tool to list user's chat channels with unread tracking
+* add discourse_get_chat_messages tool with flexible pagination and date-based filtering
+* support directional pagination (past/future) and querying around specific dates or messages
+* include smart pagination hints that guide users on how to navigate message history
+
 ### [0.1.11](https://github.com/discourse/discourse-mcp/compare/v0.1.10...v0.1.11) (2025-12-02)
 
 #### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -137,6 +137,15 @@ Built‑in tools (always present unless noted):
 - `discourse_filter_topics`
   - Input: `{ filter: string; page?: number (default 1); per_page?: number (1–50) }`
   - Query language (succinct): key:value tokens separated by spaces; category/categories (comma = OR, `=category` = without subcats, `-` prefix = exclude); tag/tags (comma = OR, `+` = AND) and tag_group; status:(open|closed|archived|listed|unlisted|public); personal `in:` (bookmarked|watching|tracking|muted|pinned); dates: created/activity/latest-post-(before|after) with `YYYY-MM-DD` or relative days `N`; numeric: likes[-op]-(min|max), posts-(min|max), posters-(min|max), views-(min|max); order: activity|created|latest-post|likes|likes-op|posters|title|views|category with optional `-asc`; free text terms are matched.
+- `discourse_list_chat_channels`
+  - Input: `{ filter?: string; limit?: number (1–100, default 25); offset?: number (default 0); status?: string }`
+  - List all public chat channels visible to the current user. Returns channel information including title, description, and member counts.
+- `discourse_list_user_chat_channels`
+  - Input: `{}`
+  - List all chat channels for the currently authenticated user, including both public channels they're a member of and direct message channels. Includes unread tracking information.
+- `discourse_get_chat_messages`
+  - Input: `{ channel_id: number; page_size?: number (1–500, default 50); target_message_id?: number; direction?: "past" | "future"; target_date?: string (ISO 8601); fetch_from_last_read?: boolean; include_target_message_id?: boolean }`
+  - Get messages from a chat channel with flexible pagination and date-based filtering. Supports: (1) paginating with direction='past'/'future' from a target_message_id, (2) querying messages around a specific target_date, (3) getting messages around a target_message_id, or (4) fetching from last read position.
 - `discourse_create_post` (only when writes enabled; see Write safety)
   - Input: `{ topic_id: number; raw: string (≤ 30k chars) }`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discourse/mcp",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Discourse MCP CLI server (stdio) exposing Discourse tools via MCP",
   "author": "Discourse",
   "license": "MIT",

--- a/src/tools/builtin/get_chat_messages.ts
+++ b/src/tools/builtin/get_chat_messages.ts
@@ -1,0 +1,187 @@
+import type { RegisterFn } from "../types.js";
+import { z } from "zod";
+
+export const registerGetChatMessages: RegisterFn = (server, ctx) => {
+  const schema = z.object({
+    channel_id: z.number().int().positive().describe("The chat channel ID"),
+    page_size: z.number().int().min(1).max(500).optional().describe("Number of messages to return (default: 50, max: 500)"),
+    target_message_id: z.number().int().positive().optional().describe("Message ID to query around or paginate from"),
+    direction: z.enum(["past", "future"]).optional().describe("Pagination direction: 'past' for older messages (DESC), 'future' for newer messages (ASC)"),
+    target_date: z.string().optional().describe("ISO 8601 date string (e.g., '2024-01-15' or '2024-01-15T10:30:00Z') to query messages around that date"),
+    fetch_from_last_read: z.boolean().optional().describe("If true, start from the user's last read message"),
+    include_target_message_id: z.boolean().optional().describe("Whether to include the target message in results (default: true)"),
+  }).strict();
+
+  server.registerTool(
+    "discourse_get_chat_messages",
+    {
+      title: "Get Chat Messages",
+      description: "Get messages from a chat channel with flexible pagination and date-based filtering. Supports: (1) paginating with direction='past'/'future' from a target_message_id, (2) querying messages around a specific target_date, (3) getting messages around a target_message_id, or (4) fetching from last read position.",
+      inputSchema: schema.shape,
+    },
+    async ({
+      channel_id,
+      page_size = 50,
+      target_message_id,
+      direction,
+      target_date,
+      fetch_from_last_read,
+      include_target_message_id
+    }, _extra: any) => {
+      try {
+        const { base, client } = ctx.siteState.ensureSelectedSite();
+
+        // Build query parameters
+        const params = new URLSearchParams();
+        params.append("page_size", String(page_size));
+
+        if (target_message_id !== undefined) {
+          params.append("target_message_id", String(target_message_id));
+        }
+
+        if (direction) {
+          params.append("direction", direction);
+        }
+
+        if (target_date) {
+          params.append("target_date", target_date);
+        }
+
+        if (fetch_from_last_read !== undefined) {
+          params.append("fetch_from_last_read", String(fetch_from_last_read));
+        }
+
+        if (include_target_message_id !== undefined) {
+          params.append("include_target_message_id", String(include_target_message_id));
+        }
+
+        const url = `/chat/api/channels/${channel_id}/messages?${params.toString()}`;
+        const data = (await client.get(url)) as any;
+
+        const messages: any[] = data?.messages || [];
+        const meta = data?.meta || {};
+
+        if (messages.length === 0) {
+          return { content: [{ type: "text", text: "No messages found in this channel." }] };
+        }
+
+        const limit = Number.isFinite(ctx.maxReadLength) ? ctx.maxReadLength : 50000;
+        const lines: string[] = [];
+
+        // Header
+        lines.push(`# Chat Messages (Channel ${channel_id})`);
+        lines.push(`Showing ${messages.length} messages`);
+        if (target_date) {
+          lines.push(`Around date: ${target_date}`);
+        }
+        if (meta.target_message_id) {
+          lines.push(`Target message ID: ${meta.target_message_id}`);
+        }
+        lines.push("");
+
+        // Pagination info
+        // Note: The API only sets flags for the direction you queried:
+        // - direction='future': only can_load_more_future is meaningful
+        // - direction='past': only can_load_more_past is meaningful
+        // - no direction: defaults to latest messages, so can_load_more_past is meaningful
+        const canLoadMorePast = meta.can_load_more_past ?? false;
+        const canLoadMoreFuture = meta.can_load_more_future ?? false;
+        const hints: string[] = [];
+
+        // When querying in a specific direction, assume the opposite direction is available
+        // unless we're at the absolute start/end of the channel
+        if (direction === "future") {
+          // Going forward in time (to newer messages)
+          if (canLoadMoreFuture) {
+            const newestId = messages[messages.length - 1]?.id;
+            hints.push(`more messages available (use direction='future' with target_message_id=${newestId})`);
+          } else {
+            hints.push(`no more messages (reached end of channel)`);
+          }
+          // We came from somewhere, so there are likely older messages
+          if (target_message_id) {
+            hints.push(`to go back, use direction='past' with target_message_id=${messages[0]?.id}`);
+          }
+        } else if (direction === "past") {
+          // Going backward in time (to older messages)
+          if (canLoadMorePast) {
+            const oldestId = messages[0]?.id;
+            hints.push(`more messages available (use direction='past' with target_message_id=${oldestId})`);
+          } else {
+            hints.push(`no more messages (reached start of channel)`);
+          }
+          // We came from somewhere, so there are likely newer messages
+          if (target_message_id) {
+            hints.push(`to go forward, use direction='future' with target_message_id=${messages[messages.length - 1]?.id}`);
+          }
+        } else {
+          // No direction specified = fetching latest messages
+          if (canLoadMorePast) {
+            const oldestId = messages[0]?.id;
+            hints.push(`older messages available (use direction='past' with target_message_id=${oldestId})`);
+          } else {
+            hints.push(`no older messages (this is the entire channel history)`);
+          }
+          // At the latest, so no newer messages
+          hints.push(`no newer messages (at end of channel)`);
+        }
+
+        if (hints.length > 0) {
+          lines.push(`_Pagination: ${hints.join("; ")}_`);
+          lines.push("");
+        }
+
+        // Messages
+        for (const msg of messages) {
+          const username = msg.user?.username || "unknown";
+          const createdAt = msg.created_at || "unknown time";
+          const messageText = (msg.message || msg.cooked || "").toString().slice(0, limit);
+          const edited = msg.edited ? " (edited)" : "";
+          const threadId = msg.thread_id ? ` [thread:${msg.thread_id}]` : "";
+          const inReplyTo = msg.in_reply_to ? ` [reply to #${msg.in_reply_to.id}]` : "";
+
+          lines.push(`## Message #${msg.id}${edited}`);
+          lines.push(`**@${username}** at ${createdAt}${threadId}${inReplyTo}`);
+          lines.push("");
+          lines.push(messageText);
+          lines.push("");
+
+          // Reactions
+          if (msg.reactions && msg.reactions.length > 0) {
+            const reactionStr = msg.reactions
+              .map((r: any) => `${r.emoji} ${r.count}`)
+              .join(", ");
+            lines.push(`_Reactions: ${reactionStr}_`);
+            lines.push("");
+          }
+
+          // Uploads/attachments
+          if (msg.uploads && msg.uploads.length > 0) {
+            lines.push("_Attachments:_");
+            for (const upload of msg.uploads) {
+              lines.push(`- ${upload.original_filename || upload.url}`);
+            }
+            lines.push("");
+          }
+
+          // Mentioned users
+          if (msg.mentioned_users && msg.mentioned_users.length > 0) {
+            const mentions = msg.mentioned_users.map((u: any) => `@${u.username}`).join(", ");
+            lines.push(`_Mentions: ${mentions}_`);
+            lines.push("");
+          }
+
+          lines.push("---");
+          lines.push("");
+        }
+
+        return { content: [{ type: "text", text: lines.join("\n") }] };
+      } catch (e: any) {
+        return {
+          content: [{ type: "text", text: `Failed to get chat messages: ${e?.message || String(e)}` }],
+          isError: true
+        };
+      }
+    }
+  );
+};

--- a/src/tools/builtin/list_chat_channels.ts
+++ b/src/tools/builtin/list_chat_channels.ts
@@ -1,0 +1,76 @@
+import type { RegisterFn } from "../types.js";
+import { z } from "zod";
+
+export const registerListChatChannels: RegisterFn = (server, ctx) => {
+  const schema = z.object({
+    filter: z.string().optional().describe("Filter channels by name/slug"),
+    limit: z.number().int().min(1).max(100).optional().describe("Number of channels to return (default: 25, max: 100)"),
+    offset: z.number().int().min(0).optional().describe("Pagination offset (default: 0)"),
+    status: z.string().optional().describe("Filter by channel status (e.g., 'open', 'closed', 'archived')"),
+  }).strict();
+
+  server.registerTool(
+    "discourse_list_chat_channels",
+    {
+      title: "List Chat Channels",
+      description: "List all public chat channels visible to the current user. Returns channel information including title, description, and member counts.",
+      inputSchema: schema.shape,
+    },
+    async ({ filter, limit = 25, offset = 0, status }, _extra: any) => {
+      try {
+        const { base, client } = ctx.siteState.ensureSelectedSite();
+
+        // Build query parameters
+        const params = new URLSearchParams();
+        if (filter) params.append("filter", filter);
+        params.append("limit", String(limit));
+        params.append("offset", String(offset));
+        if (status) params.append("status", status);
+
+        const url = `/chat/api/channels?${params.toString()}`;
+        const data = (await client.get(url)) as any;
+
+        const channels: any[] = data?.channels || [];
+
+        if (channels.length === 0) {
+          return { content: [{ type: "text", text: "No chat channels found." }] };
+        }
+
+        const lines: string[] = [];
+        lines.push(`# Chat Channels (${channels.length} shown)`);
+        lines.push("");
+
+        for (const channel of channels) {
+          const title = channel.title || `Channel ${channel.id}`;
+          const slug = channel.slug || String(channel.id);
+          const description = channel.description || "";
+          const membersCount = channel.memberships_count || 0;
+          const statusText = channel.status || "open";
+
+          lines.push(`## ${title}`);
+          lines.push(`- **ID**: ${channel.id}`);
+          lines.push(`- **Slug**: ${slug}`);
+          lines.push(`- **Status**: ${statusText}`);
+          lines.push(`- **Members**: ${membersCount}`);
+          if (description) {
+            lines.push(`- **Description**: ${description}`);
+          }
+          lines.push(`- **URL**: ${base}/chat/c/${slug}/${channel.id}`);
+          lines.push("");
+        }
+
+        // Add pagination info
+        if (data?.meta?.load_more_url) {
+          lines.push(`_More channels available. Use offset=${offset + limit} to load next page._`);
+        }
+
+        return { content: [{ type: "text", text: lines.join("\n") }] };
+      } catch (e: any) {
+        return {
+          content: [{ type: "text", text: `Failed to list chat channels: ${e?.message || String(e)}` }],
+          isError: true
+        };
+      }
+    }
+  );
+};

--- a/src/tools/builtin/list_user_chat_channels.ts
+++ b/src/tools/builtin/list_user_chat_channels.ts
@@ -1,0 +1,101 @@
+import type { RegisterFn } from "../types.js";
+import { z } from "zod";
+
+export const registerListUserChatChannels: RegisterFn = (server, ctx) => {
+  const schema = z.object({}).strict();
+
+  server.registerTool(
+    "discourse_list_user_chat_channels",
+    {
+      title: "List User's Chat Channels",
+      description: "List all chat channels for the currently authenticated user, including both public channels they're a member of and direct message channels. Includes unread tracking information.",
+      inputSchema: schema.shape,
+    },
+    async (_args, _extra: any) => {
+      try {
+        const { base, client } = ctx.siteState.ensureSelectedSite();
+
+        const url = `/chat/api/me/channels`;
+        const data = (await client.get(url)) as any;
+
+        const publicChannels: any[] = data?.public_channels || [];
+        const dmChannels: any[] = data?.direct_message_channels || [];
+        const tracking = data?.tracking || {};
+
+        const lines: string[] = [];
+        lines.push("# My Chat Channels");
+        lines.push("");
+
+        // Public channels
+        if (publicChannels.length > 0) {
+          lines.push(`## Public Channels (${publicChannels.length})`);
+          lines.push("");
+          for (const channel of publicChannels) {
+            const title = channel.title || `Channel ${channel.id}`;
+            const slug = channel.slug || String(channel.id);
+            const unreadCount = tracking?.channel_tracking?.[channel.id]?.unread_count || 0;
+            const mentionCount = tracking?.channel_tracking?.[channel.id]?.mention_count || 0;
+
+            lines.push(`### ${title}`);
+            lines.push(`- **ID**: ${channel.id}`);
+            lines.push(`- **Slug**: ${slug}`);
+            lines.push(`- **Status**: ${channel.status || "open"}`);
+            if (unreadCount > 0) {
+              lines.push(`- **Unread**: ${unreadCount} messages`);
+            }
+            if (mentionCount > 0) {
+              lines.push(`- **Mentions**: ${mentionCount}`);
+            }
+            if (channel.last_message) {
+              const lastMsg = channel.last_message;
+              lines.push(`- **Last Message**: by @${lastMsg.user?.username || "unknown"} at ${lastMsg.created_at || "unknown time"}`);
+            }
+            lines.push(`- **URL**: ${base}/chat/c/${slug}/${channel.id}`);
+            lines.push("");
+          }
+        } else {
+          lines.push("## Public Channels");
+          lines.push("No public channels.");
+          lines.push("");
+        }
+
+        // Direct message channels
+        if (dmChannels.length > 0) {
+          lines.push(`## Direct Messages (${dmChannels.length})`);
+          lines.push("");
+          for (const channel of dmChannels) {
+            const title = channel.title || `DM ${channel.id}`;
+            const unreadCount = tracking?.channel_tracking?.[channel.id]?.unread_count || 0;
+            const mentionCount = tracking?.channel_tracking?.[channel.id]?.mention_count || 0;
+
+            lines.push(`### ${title}`);
+            lines.push(`- **ID**: ${channel.id}`);
+            if (unreadCount > 0) {
+              lines.push(`- **Unread**: ${unreadCount} messages`);
+            }
+            if (mentionCount > 0) {
+              lines.push(`- **Mentions**: ${mentionCount}`);
+            }
+            if (channel.last_message) {
+              const lastMsg = channel.last_message;
+              lines.push(`- **Last Message**: by @${lastMsg.user?.username || "unknown"} at ${lastMsg.created_at || "unknown time"}`);
+            }
+            lines.push(`- **URL**: ${base}/chat/c/-/${channel.id}`);
+            lines.push("");
+          }
+        } else {
+          lines.push("## Direct Messages");
+          lines.push("No direct message channels.");
+          lines.push("");
+        }
+
+        return { content: [{ type: "text", text: lines.join("\n") }] };
+      } catch (e: any) {
+        return {
+          content: [{ type: "text", text: `Failed to list user chat channels: ${e?.message || String(e)}` }],
+          isError: true
+        };
+      }
+    }
+  );
+};

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -14,6 +14,9 @@ import { registerSelectSite } from "./builtin/select_site.js";
 import { registerFilterTopics } from "./builtin/filter_topics.js";
 import { registerCreateUser } from "./builtin/create_user.js";
 import { registerListUserPosts } from "./builtin/list_user_posts.js";
+import { registerListChatChannels } from "./builtin/list_chat_channels.js";
+import { registerListUserChatChannels } from "./builtin/list_user_chat_channels.js";
+import { registerGetChatMessages } from "./builtin/get_chat_messages.js";
 
 export type ToolsMode = "auto" | "discourse_api_only" | "tool_exec_api";
 
@@ -46,6 +49,9 @@ export async function registerAllTools(
   registerGetUser(server, ctx, { allowWrites: false });
   registerListUserPosts(server, ctx, { allowWrites: false });
   registerFilterTopics(server, ctx, { allowWrites: false });
+  registerListChatChannels(server, ctx, { allowWrites: false });
+  registerListUserChatChannels(server, ctx, { allowWrites: false });
+  registerGetChatMessages(server, ctx, { allowWrites: false });
   registerCreatePost(server, ctx, { allowWrites: opts.allowWrites });
   registerCreateUser(server, ctx, { allowWrites: opts.allowWrites });
   registerCreateCategory(server, ctx, { allowWrites: opts.allowWrites });


### PR DESCRIPTION
## Summary

Adds three new MCP tools for interacting with Discourse Chat, enabling LLMs to list channels, read messages, and navigate chat history.

## New Tools

### 1. `discourse_list_chat_channels`
Lists all public chat channels visible to the current user.

**Parameters:**
- `filter` (optional): Filter channels by name/slug
- `limit` (optional): Number of channels (1-100, default: 25)
- `offset` (optional): Pagination offset (default: 0)
- `status` (optional): Filter by status (open/closed/archived)

### 2. `discourse_list_user_chat_channels`
Lists the authenticated user's chat channels, including both public channels and DMs.

**Features:**
- Separates public channels from direct messages
- Includes unread message counts and mention tracking
- Shows last message details for each channel

### 3. `discourse_get_chat_messages`
Retrieves messages from a chat channel with flexible pagination.

**Parameters:**
- `channel_id` (required): The chat channel ID
- `page_size` (optional): Messages to return (1-500, default: 50)
- `target_message_id` (optional): Message ID to paginate from
- `direction` (optional): "past" (older) or "future" (newer)
- `target_date` (optional): ISO 8601 date to query around
- `fetch_from_last_read` (optional): Start from user's last read position

**Features:**
- Smart pagination hints that adapt based on query direction
- Handles Discourse's counter-intuitive API naming correctly
- Shows message content, reactions, attachments, mentions, and thread info
- Respects `maxReadLength` configuration

## Design Decisions

- **Text-only output**: No redundant JSON footers (IDs are already in readable text)
- **Smart pagination**: Direction-aware hints guide users through message history
- **Follows existing patterns**: Matches the style of other MCP tools like `list_categories`

## Testing

- ✅ TypeScript type checking passes
- ✅ Build completes successfully
- ✅ Manually tested pagination logic with real chat data

## Version

Bumped to `0.1.12` with changelog entry.