### PR TITLE
FEATURE: Add support for more params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,18 @@
 Changelog
+### [0.1.15](https://github.com/discourse/discourse-mcp/compare/v0.1.14...v0.1.15) (2025-12-26)
+
+#### Features
+
+* add support for `emoji` and `icon` params in discourse_create_category tool
+* add support for `author_username` and `author_user_id` params in discourse_create_post tool
+* add support for `author_username` and `author_user_id` params in discourse_create_topic tool
+
+### [0.1.14](https://github.com/discourse/discourse-mcp/compare/v0.1.13...v0.1.14) (2025-12-19)
+
+#### Features
+
+* change github link in the User Agent string 
+
 ### [0.1.13](https://github.com/discourse/discourse-mcp/compare/v0.1.12...v0.1.13) (2025-12-03)
 
 #### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discourse/mcp",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Discourse MCP CLI server (stdio) exposing Discourse tools via MCP",
   "author": "Discourse",
   "license": "MIT",

--- a/src/tools/builtin/create_category.ts
+++ b/src/tools/builtin/create_category.ts
@@ -10,6 +10,8 @@ export const registerCreateCategory: RegisterFn = (server, ctx, opts) => {
     name: z.string().min(1).max(100),
     color: z.string().regex(/^[0-9a-fA-F]{6}$/).optional(),
     text_color: z.string().regex(/^[0-9a-fA-F]{6}$/).optional(),
+    emoji: z.string().optional(),
+    icon: z.string().optional(),
     parent_category_id: z.number().int().positive().optional(),
     description: z.string().min(1).max(10000).optional(),
   });
@@ -22,7 +24,7 @@ export const registerCreateCategory: RegisterFn = (server, ctx, opts) => {
       inputSchema: schema.shape,
     },
     async (input: any, _extra: any) => {
-      const { name, color, text_color, parent_category_id, description } = schema.parse(input);
+      const { name, color, text_color, emoji, icon, parent_category_id, description } = schema.parse(input);
 
       // Simple 1 req/sec rate limit
       const now = Date.now();
@@ -40,6 +42,13 @@ export const registerCreateCategory: RegisterFn = (server, ctx, opts) => {
         if (text_color) payload.text_color = text_color;
         if (parent_category_id) payload.parent_category_id = parent_category_id;
         if (description) payload.description = description;
+        if (emoji) payload.emoji = emoji;
+        if (icon) payload.icon = icon;
+        if (emoji) {
+          payload.style_type = 2;
+        } else if (icon) {
+          payload.style_type = 1;
+        }
 
         const data: any = await client.post(`/categories.json`, payload);
         const category = data?.category || data;

--- a/src/tools/builtin/create_topic.ts
+++ b/src/tools/builtin/create_topic.ts
@@ -11,6 +11,8 @@ export const registerCreateTopic: RegisterFn = (server, ctx, opts) => {
     raw: z.string().min(1).max(30000),
     category_id: z.number().int().positive().optional(),
     tags: z.array(z.string().min(1).max(100)).max(10).optional(),
+    author_username: z.string().optional(),
+    author_user_id: z.number().optional(),
   });
 
   server.registerTool(
@@ -21,7 +23,7 @@ export const registerCreateTopic: RegisterFn = (server, ctx, opts) => {
       inputSchema: schema.shape,
     },
     async (input: any, _extra: any) => {
-      const { title, raw, category_id, tags } = schema.parse(input);
+      const { title, raw, category_id, tags, author_username, author_user_id } = schema.parse(input);
 
       // Simple 1 req/sec rate limit
       const now = Date.now();
@@ -37,6 +39,8 @@ export const registerCreateTopic: RegisterFn = (server, ctx, opts) => {
         const payload: any = { title, raw };
         if (typeof category_id === "number") payload.category = category_id;
         if (Array.isArray(tags) && tags.length > 0) payload.tags = tags;
+        if (author_username && author_username.length > 0) payload.author_username = author_username;
+        if (typeof author_user_id === "number") payload.author_user_id = author_user_id;
 
         const data: any = await client.post(`/posts.json`, payload);
 


### PR DESCRIPTION
The new params in `discourse_create_topic` and `discourse_create_post` tools will only work against Discourse sites running a version that contains https://github.com/discourse/discourse/pull/36862.