### PR TITLE
FEATURE: Ability to create post as other users by overriding Api-Username header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 Changelog
+### [0.1.16](https://github.com/discourse/discourse-mcp/compare/v0.1.15...v0.1.16) (2025-12-30)
+
+#### Features
+
+* ability to create post as another user by overriding Api-Username header
+
+#### Breaking Changes
+
+* remove `author_user_id` param from discourse_create_post tool
+* remove `author_user_id` param from discourse_create_topic tool
+
 ### [0.1.15](https://github.com/discourse/discourse-mcp/compare/v0.1.14...v0.1.15) (2025-12-26)
 
 #### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discourse/mcp",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Discourse MCP CLI server (stdio) exposing Discourse tools via MCP",
   "author": "Discourse",
   "license": "MIT",

--- a/src/http/client.ts
+++ b/src/http/client.ts
@@ -43,8 +43,8 @@ export class HttpClient {
     return h;
   }
 
-  async get(path: string, { signal }: { signal?: AbortSignal } = {}) {
-    return this.request("GET", path, undefined, { signal });
+  async get(path: string, { signal, headers }: { signal?: AbortSignal, headers?: Record<string, string>} = {}) {
+    return this.request("GET", path, undefined, { signal, extraHeaders: headers });
   }
 
   async getCached(path: string, ttlMs: number, { signal }: { signal?: AbortSignal } = {}) {
@@ -57,19 +57,22 @@ export class HttpClient {
     return value;
   }
 
-  async post(path: string, body: unknown, { signal }: { signal?: AbortSignal } = {}) {
-    return this.request("POST", path, body, { signal });
+  async post(path: string, body: unknown, { signal, headers }: { signal?: AbortSignal, headers?: Record<string, string>} = {}) {
+    return this.request("POST", path, body, { signal, extraHeaders: headers});
   }
 
-  async delete(path: string, body?: unknown, { signal }: { signal?: AbortSignal } = {}) {
-    return this.request("DELETE", path, body, { signal });
+  async delete(path: string, body?: unknown, { signal, headers }: { signal?: AbortSignal, headers?: Record<string, string>} = {}) {
+    return this.request("DELETE", path, body, { signal, extraHeaders: headers });
   }
 
-  private async request(method: string, path: string, body?: unknown, { signal }: { signal?: AbortSignal } = {}) {
+  private async request(method: string, path: string, body?: unknown, { signal, extraHeaders }: { signal?: AbortSignal, extraHeaders?: Record<string, string>} = {}) {
     const url = new URL(path, this.base).toString();
     const headers = this.headers();
     if (body !== undefined) {
       headers["Content-Type"] = "application/json";
+    }
+    if (extraHeaders) {
+      Object.assign(headers, extraHeaders);
     }
 
     this.opts.logger.debug(`HTTP ${method} ${url}`);

--- a/src/tools/builtin/create_post.ts
+++ b/src/tools/builtin/create_post.ts
@@ -10,7 +10,6 @@ export const registerCreatePost: RegisterFn = (server, ctx, opts) => {
     topic_id: z.number().int().positive(),
     raw: z.string().min(1).max(30000),
     author_username: z.string().optional(),
-    author_user_id: z.number().optional(),
   });
 
   server.registerTool(
@@ -21,7 +20,7 @@ export const registerCreatePost: RegisterFn = (server, ctx, opts) => {
       inputSchema: schema.shape,
     },
     async (input: any, _extra: any) => {
-      const { topic_id, raw, author_username, author_user_id } = schema.parse(input);
+      const { topic_id, raw, author_username } = schema.parse(input);
 
       // Simple 1 req/sec rate limit
       const now = Date.now();
@@ -34,11 +33,11 @@ export const registerCreatePost: RegisterFn = (server, ctx, opts) => {
       try {
         const { base, client } = ctx.siteState.ensureSelectedSite();
         const payload: any = { topic_id, raw };
+        const headers: Record<string, string> = {};
 
-        if (author_username && author_username.length > 0) payload.author_username = author_username;
-        if (typeof author_user_id === "number") payload.author_user_id = author_user_id;
+        if (author_username && author_username.length > 0) headers["Api-Username"] = author_username;
 
-        const data = (await client.post(`/posts.json`, payload)) as any;
+        const data = (await client.post(`/posts.json`, payload, { headers })) as any;
         const postId = data?.id || data?.post?.id;
         const topicId = data?.topic_id || topic_id;
         const postNumber = data?.post_number || data?.post?.post_number;


### PR DESCRIPTION
Follow-up to https://github.com/discourse/discourse-mcp/pull/24

Note that the used API key must a global key for the override to be allowed by Discourse, i.e. the API key can't be associated to any user (even an admin).