### PR TITLE
DEV: Bump version to 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.2.0](https://github.com/discourse/discourse-mcp/compare/v0.1.17...v0.2.0) (2026-01-13)
+## [0.2.1](https://github.com/discourse/discourse-mcp/compare/v0.1.17...v0.2.1) (2026-01-13)
 
 ### Breaking Changes
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@discourse/mcp",
   "mcpName": "io.github.discourse/mcp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Discourse MCP CLI server (stdio) exposing Discourse tools via MCP",
   "author": "Discourse",
   "license": "MIT",


### PR DESCRIPTION
v0.2.0 was partially registered in MCP registry, preventing republish.