### PR TITLE
FEATURE: add HTTP Basic Auth support for sites behind reverse proxies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@
 - Supported auth:
   - **None** (read-only public data)
   - Per-site overrides via `--auth_pairs`, e.g. `[{"site":"https://example.com","api_key":"...","api_username":"system"}]`.
+  - **HTTP Basic Auth** (for sites behind a reverse proxy): Add `http_basic_user` and `http_basic_pass` to any `auth_pairs` entry.
 - **Writes are disabled by default**. Write tools are only registered when:
   - `--allow_writes` AND not `--read_only` AND a matching `auth_pairs` entry exists for the selected site.
 - Secrets are never logged; config is redacted before logging.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.2](https://github.com/discourse/discourse-mcp/compare/v0.2.1...v0.2.2) (2026-01-14)
+
+### Features
+
+* Add HTTP Basic Auth support for sites behind reverse proxies
+  - New `http_basic_user` and `http_basic_pass` fields in `auth_pairs` configuration
+  - Sends `Authorization: Basic` header alongside Discourse API authentication headers
+
 ## [0.2.1](https://github.com/discourse/discourse-mcp/compare/v0.1.17...v0.2.1) (2026-01-13)
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The server registers tools under the MCP server name `@discourse/mcp`. Choose a 
   - **None** by default.
   - **Admin API Keys** (require admin permissions): **`--auth_pairs '[{"site":"https://example.com","api_key":"...","api_username":"system"}]'`**
   - **User API Keys** (any user can generate): **`--auth_pairs '[{"site":"https://example.com","user_api_key":"...","user_api_client_id":"..."}]'`**
+  - **HTTP Basic Auth** (for sites behind a reverse proxy): Add `http_basic_user` and `http_basic_pass` to any `auth_pairs` entry. This is useful for Discourse sites protected by HTTP Basic Authentication at the reverse proxy level.
   - You can include multiple entries in `auth_pairs`; the matching entry is used for the selected site. If both `user_api_key` and `api_key` are provided for the same site, `user_api_key` takes precedence.
 
 - **Write safety**
@@ -105,6 +106,13 @@ The server registers tools under the MCP server name `@discourse/mcp`. Choose a 
       "site": "https://example.com",
       "user_api_key": "<user_api_key>",
       "user_api_client_id": "<client_id>"
+    },
+    {
+      "site": "https://protected.example.com",
+      "api_key": "<redacted>",
+      "api_username": "system",
+      "http_basic_user": "username",
+      "http_basic_pass": "password"
     }
   ],
   "read_only": false,
@@ -339,6 +347,12 @@ npx -y @discourse/mcp@latest --transport http --port 3000 --site https://try.dis
 # Server will start on http://localhost:3000
 # Health check: http://localhost:3000/health
 # MCP endpoint: http://localhost:3000/mcp
+```
+
+- Connect to a site behind HTTP Basic Auth:
+
+```bash
+npx -y @discourse/mcp@latest --auth_pairs '[{"site":"https://protected.example.com","api_key":"'$DISCOURSE_API_KEY'","api_username":"system","http_basic_user":"username","http_basic_pass":"password"}]' --site https://protected.example.com
 ```
 
 ## Authentication

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@discourse/mcp",
   "mcpName": "io.github.discourse/mcp",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Discourse MCP CLI server (stdio) exposing Discourse tools via MCP",
   "author": "Discourse",
   "license": "MIT",

--- a/src/http/client.ts
+++ b/src/http/client.ts
@@ -10,6 +10,7 @@ export interface HttpClientOptions {
   timeoutMs: number;
   logger: Logger;
   auth: AuthMode;
+  httpBasicAuth?: { user: string; pass: string };
 }
 
 export class HttpError extends Error {
@@ -39,6 +40,11 @@ export class HttpClient {
     } else if (this.opts.auth.type === "user_api_key") {
       h["User-Api-Key"] = this.opts.auth.key;
       if (this.opts.auth.client_id) h["User-Api-Client-Id"] = this.opts.auth.client_id;
+    }
+    if (this.opts.httpBasicAuth) {
+      const { user, pass } = this.opts.httpBasicAuth;
+      const encoded = Buffer.from(`${user}:${pass}`).toString("base64");
+      h["Authorization"] = `Basic ${encoded}`;
     }
     return h;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,8 @@ const ProfileSchema = z
             api_username: z.string().optional(),
             user_api_key: z.string().optional(),
             user_api_client_id: z.string().optional(),
+            http_basic_user: z.string().optional(),
+            http_basic_pass: z.string().optional(),
           })
           .strict()
       )

--- a/src/util/redact.ts
+++ b/src/util/redact.ts
@@ -1,5 +1,7 @@
 export function redactSecrets(input: string): string {
-  return input.replace(/(Api-Key|User-Api-Key|Authorization):\s*([^\s]+)/gi, "$1: <redacted>");
+  return input
+    .replace(/(Api-Key|User-Api-Key|Authorization):\s*([^\s]+)/gi, "$1: <redacted>")
+    .replace(/"http_basic_pass"\s*:\s*"[^"]*"/gi, '"http_basic_pass": "<redacted>"');
 }
 
 export function redactObject<T>(obj: T): T {


### PR DESCRIPTION
Add support for HTTP Basic Authentication credentials in auth_pairs configuration. This is useful for Discourse sites protected by HTTP Basic Auth at the reverse proxy level.

- Add `http_basic_user` and `http_basic_pass` fields to auth_pairs schema
- Send `Authorization: Basic` header alongside Discourse API auth headers
- Redact http_basic_pass in config logs for security
- Update documentation (README, AGENTS.md, CHANGELOG)
- Bump version to 0.2.2