### PR TITLE
FIX: tags resource, pagination, and documentation accuracy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,8 @@ Resources provide static/semi-static data via URI addressing. Use these instead 
 
 - **discourse://site/tags**
 
-  - **Output**: JSON with `tags` array (`id`, `count`) and `meta.total`
+  - **Output**: JSON with `tags` array (`id`, `name`, `count`) and `meta.total`
+  - **Tag fields**: `id` (numeric database ID), `name` (tag name used in filters), `count` (topic count)
 
 - **discourse://site/groups**
 
@@ -97,6 +98,7 @@ All tools return **strict JSON** (no Markdown). Every response includes relevant
 
   - **Input**: `{ username: string; page?: number (0-based); limit?: number (1–50, default 30) }`
   - **Output**: `{ posts: [{id, topic_id, post_number, slug, title, created_at, excerpt, category_id}], meta: {page, limit, has_more} }`
+  - **Note**: `id` is `null` for first posts (topic creation, `post_number: 1`); use `topic_id` + `post_number` to reference these posts
 
 - **discourse_get_chat_messages**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [0.2.3](https://github.com/discourse/discourse-mcp/compare/v0.2.2...v0.2.3) (2026-01-14)
+
+### Bug Fixes
+
+* Fix tags resource to include tag names alongside id and count
+  - `discourse://site/tags` now returns `{id, name, count}` instead of just `{id, count}`
+  - Tag `name` is the string used in filters (e.g., `tag:mcp-test`)
+
+* Fix `discourse_list_user_posts` to always include `id` field
+  - `id` is now always present (may be `null` for first posts/topic creation where `post_number: 1`)
+  - Use `topic_id` + `post_number` to reference posts when `id` is `null`
+
+* Fix `discourse_filter_topics` to respect `per_page` limit
+  - Results are now properly sliced to the requested `per_page` value
+  - `has_more` correctly indicates when more results are available
+
+### Documentation
+
+* Fix tool descriptions to accurately describe return types:
+  - `discourse_filter_topics`: "Returns JSON array" → "Returns JSON object with results array"
+  - `discourse_get_chat_messages`: "Returns JSON array" → "Returns JSON object with channel_id, messages array, and meta"
+  - `discourse_get_user`: Added missing `admin, moderator` fields to description
+  - `discourse_list_user_posts`: Clarified return structure with posts array and meta
+
+* Update README.md to reflect correct output formats for tags and chat messages
+
 ## [0.2.2](https://github.com/discourse/discourse-mcp/compare/v0.2.1...v0.2.2) (2026-01-14)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Model Context Protocol (MCP) stdio server that exposes Discourse forum capabil
 - **Entry point**: `src/index.ts` → compiled to `dist/index.js` (binary name: `discourse-mcp`)
 - **SDK**: `@modelcontextprotocol/sdk`
 - **Node**: >= 18
-- **Version**: 0.2.0 (breaking changes from 0.1.x - JSON-only output, resources replace list tools)
+- **Version**: 0.2.3 (0.2.x has breaking changes from 0.1.x - JSON-only output, resources replace list tools)
 
 ### Quick start (release)
 
@@ -161,7 +161,7 @@ Resources provide static/semi-static read-only data via URI addressing. Use thes
 - **discourse://site/tags**
 
   - List all tags with usage counts
-  - Output: `{ tags: [{id, count}], meta: {total} }`
+  - Output: `{ tags: [{id, name, count}], meta: {total} }`
 
 - **discourse://site/groups**
 
@@ -211,7 +211,7 @@ Built‑in tools (always present unless noted). All tools return **strict JSON**
   - Query language (succinct): key:value tokens separated by spaces; category/categories (comma = OR, `=category` = without subcats, `-` prefix = exclude); tag/tags (comma = OR, `+` = AND) and tag_group; status:(open|closed|archived|listed|unlisted|public); personal `in:` (bookmarked|watching|tracking|muted|pinned); dates: created/activity/latest-post-(before|after) with `YYYY-MM-DD` or relative days `N`; numeric: likes[-op]-(min|max), posts-(min|max), posters-(min|max), views-(min|max); order: activity|created|latest-post|likes|likes-op|posters|title|views|category with optional `-asc`; free text terms are matched.
 - `discourse_get_chat_messages`
   - Input: `{ channel_id: number; page_size?: number (1–50, default 50); target_message_id?: number; direction?: "past" | "future"; target_date?: string (ISO 8601) }`
-  - Output: `{ messages: [{id, username, created_at, message, edited, thread_id, in_reply_to_id}], meta }`
+  - Output: `{ channel_id, messages: [{id, username, created_at, message, edited, thread_id, in_reply_to_id}], meta }`
 - `discourse_get_draft`
   - Input: `{ draft_key: string; sequence?: number }`
   - Output: `{ draft_key, sequence, found, data: {title, reply, category_id, tags, action} }`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@discourse/mcp",
   "mcpName": "io.github.discourse/mcp",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Discourse MCP CLI server (stdio) exposing Discourse tools via MCP",
   "author": "Discourse",
   "license": "MIT",

--- a/src/tools/builtin/filter_topics.ts
+++ b/src/tools/builtin/filter_topics.ts
@@ -28,7 +28,7 @@ export const registerFilterTopics: RegisterFn = (server, ctx) => {
     .strict();
 
   const description =
-    "Filter topics with a concise query language. Returns JSON array with id, slug, title. " +
+    "Filter topics with a concise query language. Returns JSON object with results array (id, slug, title) and meta (page, limit, has_more). " +
     "Query syntax: category/categories (comma=OR, '=category'=without subcats, '-'=exclude), " +
     "tag/tags (comma=OR, '+'=AND), status:(open|closed|archived|listed|unlisted|public), " +
     "in:(bookmarked|watching|tracking|muted|pinned), dates: created/activity-(before|after) YYYY-MM-DD or N days, " +
@@ -57,7 +57,10 @@ export const registerFilterTopics: RegisterFn = (server, ctx) => {
         const moreUrl: string | undefined =
           list?.more_topics_url || list?.more_url || undefined;
 
-        const results = topics.map((t) => ({
+        const slicedTopics = topics.slice(0, per_page);
+        const hasMore = !!moreUrl || topics.length > per_page;
+
+        const results = slicedTopics.map((t) => ({
           id: t.id,
           slug: t.slug || String(t.id),
           title: t.title || t.fancy_title || `Topic ${t.id}`,
@@ -66,7 +69,7 @@ export const registerFilterTopics: RegisterFn = (server, ctx) => {
         return jsonResponse(paginatedResponse("results", results, {
           page,
           limit: per_page,
-          has_more: !!moreUrl,
+          has_more: hasMore,
         }));
       } catch (e: any) {
         return jsonError(`Failed to filter topics: ${e?.message || String(e)}`);

--- a/src/tools/builtin/get_chat_messages.ts
+++ b/src/tools/builtin/get_chat_messages.ts
@@ -15,7 +15,7 @@ export const registerGetChatMessages: RegisterFn = (server, ctx) => {
     "discourse_get_chat_messages",
     {
       title: "Get Chat Messages",
-      description: "Get messages from a chat channel. Returns JSON array with id, username, created_at, message, and pagination meta.",
+      description: "Get messages from a chat channel. Returns JSON object with channel_id, messages array (id, username, created_at, message, edited, thread_id, in_reply_to_id), and meta.",
       inputSchema: schema.shape,
     },
     async ({

--- a/src/tools/builtin/get_user.ts
+++ b/src/tools/builtin/get_user.ts
@@ -11,7 +11,7 @@ export const registerGetUser: RegisterFn = (server, ctx) => {
     "discourse_get_user",
     {
       title: "Get User",
-      description: "Get user info. Returns JSON with id, username, name, trust_level, created_at, and bio.",
+      description: "Get user info. Returns JSON with id, username, name, trust_level, created_at, bio, admin, and moderator.",
       inputSchema: schema.shape,
     },
     async ({ username }, _extra: any) => {

--- a/src/tools/builtin/list_user_posts.ts
+++ b/src/tools/builtin/list_user_posts.ts
@@ -13,7 +13,7 @@ export const registerListUserPosts: RegisterFn = (server, ctx) => {
     "discourse_list_user_posts",
     {
       title: "List User Posts",
-      description: "Get paginated list of user posts/replies. Returns JSON with post id, topic_id, post_number, created_at, excerpt, and category_id.",
+      description: "Get paginated list of user posts/replies. Returns JSON object with posts array (id, topic_id, post_number, slug, title, created_at, excerpt, category_id) and meta (page, limit, has_more).",
       inputSchema: schema.shape,
     },
     async ({ username, page = 0, limit = 30 }, _extra: any) => {
@@ -28,16 +28,19 @@ export const registerListUserPosts: RegisterFn = (server, ctx) => {
 
         const userActions = data?.user_actions || [];
 
-        const posts = userActions.slice(0, limit).map((action: any) => ({
-          id: action.post_id || action.id,
-          topic_id: action.topic_id,
-          post_number: action.post_number,
-          slug: action.slug,
-          title: action.title,
-          created_at: action.created_at,
-          excerpt: action.excerpt || null,
-          category_id: action.category_id || null,
-        }));
+        const posts = userActions.slice(0, limit).map((action: any) => {
+          const postId = action.post_id ?? action.id ?? null;
+          return {
+            id: postId,
+            topic_id: action.topic_id,
+            post_number: action.post_number,
+            slug: action.slug,
+            title: action.title,
+            created_at: action.created_at,
+            excerpt: action.excerpt || null,
+            category_id: action.category_id || null,
+          };
+        });
 
         return jsonResponse(paginatedResponse("posts", posts, {
           page,

--- a/src/util/json_response.ts
+++ b/src/util/json_response.ts
@@ -164,15 +164,19 @@ export function transformGroup(raw: any): LeanGroup {
 
 /**
  * Transforms raw Discourse tag data to lean format.
+ * Note: Discourse tags use `name` as the primary identifier (used in filters).
+ * The `id` field is the numeric database ID.
  */
 export interface LeanTag {
-  id: string;
+  id: number;
+  name: string;
   count: number;
 }
 
 export function transformTag(raw: any): LeanTag {
   return {
-    id: raw.id ?? raw.name,
+    id: raw.id ?? 0,
+    name: raw.name ?? raw.text ?? String(raw.id),
     count: raw.count ?? raw.topic_count ?? 0,
   };
 }


### PR DESCRIPTION
- Fix tags resource to include tag names alongside id and count
- Fix discourse_list_user_posts to always include id field (null for first posts)
- Fix discourse_filter_topics to respect per_page limit
- Fix tool descriptions to accurately describe JSON return types
- Update README.md and AGENTS.md documentation
- Bump version to 0.2.3