### PR TITLE
FEATURE: add user management and file upload tools

### DIFF
--- a/src/site/state.ts
+++ b/src/site/state.ts
@@ -44,6 +44,18 @@ export class SiteState {
     return { base: this.currentSiteBase, client: this.currentClient };
   }
 
+  /**
+   * Get the auth type for the current site (or a specific site URL).
+   * Returns "api_key", "user_api_key", or "none".
+   */
+  getAuthType(siteUrl?: string): "api_key" | "user_api_key" | "none" {
+    const base = siteUrl ? normalizeBase(siteUrl) : this.currentSiteBase;
+    if (!base) return "none";
+    const match = this.findAuthOverride(base);
+    const auth = this.resolveAuthFromOverride(match);
+    return auth.type;
+  }
+
   buildClientForSite(siteUrl: string): { base: string; client: HttpClient } {
     const base = normalizeBase(siteUrl);
     const cached = this.clientCache.get(base);

--- a/src/tools/builtin/list_users.ts
+++ b/src/tools/builtin/list_users.ts
@@ -1,0 +1,75 @@
+import { z } from "zod";
+import type { RegisterFn } from "../types.js";
+import { jsonResponse, jsonError, paginatedResponse } from "../../util/json_response.js";
+
+// Discourse admin API returns ~100 users per page (fixed by the API)
+const DISCOURSE_PAGE_SIZE = 100;
+
+export const registerListUsers: RegisterFn = (server, ctx) => {
+  const schema = z.object({
+    query: z.enum(["active", "new", "staff", "suspended", "silenced", "pending", "staged"])
+      .optional()
+      .default("active")
+      .describe("User query type"),
+    filter: z.string().optional().describe("Search by username, email, or IP address"),
+    order: z.enum(["created", "last_emailed", "seen", "username", "trust_level", "days_visited", "posts"])
+      .optional()
+      .describe("Sort order field"),
+    asc: z.boolean().optional().default(false).describe("Sort ascending (default: false/descending)"),
+    page: z.number().int().min(0).optional().describe("Page number (0-indexed)"),
+  });
+
+  server.registerTool(
+    "discourse_list_users",
+    {
+      title: "List Users",
+      description: "List users via admin API. Requires admin API key. Returns ~100 users per page (Discourse's fixed page size). Returns JSON with users array and pagination meta.",
+      inputSchema: schema.shape,
+    },
+    async (args, _extra: any) => {
+      try {
+        const { client } = ctx.siteState.ensureSelectedSite();
+
+        const query = args.query || "active";
+        // Discourse uses 1-indexed pages internally
+        const discoursePage = (args.page ?? 0) + 1;
+
+        // Build query parameters
+        const params = new URLSearchParams();
+        params.set("page", String(discoursePage));
+        if (args.filter) params.set("filter", args.filter);
+        if (args.order) params.set("order", args.order);
+        if (args.asc) params.set("asc", "true");
+
+        const data = (await client.get(
+          `/admin/users/list/${query}.json?${params.toString()}`
+        )) as any[];
+
+        // Discourse returns array directly for admin user list
+        const users = (data || []).map((user: any) => ({
+          id: user.id,
+          username: user.username,
+          name: user.name || null,
+          email: user.email || null,
+          avatar_template: user.avatar_template || null,
+          trust_level: user.trust_level ?? 0,
+          created_at: user.created_at || null,
+          last_seen_at: user.last_seen_at || null,
+          admin: user.admin ?? false,
+          moderator: user.moderator ?? false,
+          suspended: user.suspended ?? false,
+          silenced: user.silenced ?? false,
+        }));
+
+        return jsonResponse(paginatedResponse("users", users, {
+          page: args.page ?? 0,
+          limit: DISCOURSE_PAGE_SIZE,
+          // has_more if we got a full page (likely more results exist)
+          has_more: (data || []).length >= DISCOURSE_PAGE_SIZE,
+        }));
+      } catch (e: any) {
+        return jsonError(`Failed to list users: ${e?.message || String(e)}`);
+      }
+    }
+  );
+};

--- a/src/tools/builtin/update_user.ts
+++ b/src/tools/builtin/update_user.ts
@@ -1,0 +1,147 @@
+import { z } from "zod";
+import type { RegisterFn } from "../types.js";
+import { jsonResponse, jsonError, rateLimit } from "../../util/json_response.js";
+
+export const registerUpdateUser: RegisterFn = (server, ctx, opts) => {
+  if (!opts?.allowWrites) return;
+
+  const schema = z.object({
+    username: z.string().min(1).describe("Username of user to update"),
+    name: z.string().optional().describe("Display name"),
+    bio_raw: z.string().optional().describe("Bio in markdown"),
+    location: z.string().optional().describe("Location"),
+    website: z.string().url().optional().describe("Website URL"),
+    title: z.string().optional().describe("User title"),
+    date_of_birth: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional().describe("Date of birth (YYYY-MM-DD)"),
+    locale: z.string().optional().describe("Language preference"),
+    profile_background_upload_url: z.string().optional().describe("Profile background image URL"),
+    card_background_upload_url: z.string().optional().describe("Card background image URL"),
+    upload_id: z.number().int().positive().optional().describe("Avatar upload_id (from discourse_upload_file)"),
+  });
+
+  server.registerTool(
+    "discourse_update_user",
+    {
+      title: "Update User",
+      description: "Update user profile fields. If upload_id is provided, also sets the user's avatar. Returns JSON with success status and updated user details.",
+      inputSchema: schema.shape,
+    },
+    async (args, _extra: any) => {
+      try {
+        await rateLimit("user");
+        const { client } = ctx.siteState.ensureSelectedSite();
+
+        const { username, upload_id, ...profileFields } = args;
+
+        // Build update payload - only include fields that were provided
+        const updatePayload: Record<string, any> = {};
+        const updatedFields: string[] = [];
+
+        if (profileFields.name !== undefined) {
+          updatePayload.name = profileFields.name;
+          updatedFields.push("name");
+        }
+        if (profileFields.bio_raw !== undefined) {
+          updatePayload.bio_raw = profileFields.bio_raw;
+          updatedFields.push("bio_raw");
+        }
+        if (profileFields.location !== undefined) {
+          updatePayload.location = profileFields.location;
+          updatedFields.push("location");
+        }
+        if (profileFields.website !== undefined) {
+          updatePayload.website = profileFields.website;
+          updatedFields.push("website");
+        }
+        if (profileFields.title !== undefined) {
+          updatePayload.title = profileFields.title;
+          updatedFields.push("title");
+        }
+        if (profileFields.date_of_birth !== undefined) {
+          updatePayload.date_of_birth = profileFields.date_of_birth;
+          updatedFields.push("date_of_birth");
+        }
+        if (profileFields.locale !== undefined) {
+          updatePayload.locale = profileFields.locale;
+          updatedFields.push("locale");
+        }
+        if (profileFields.profile_background_upload_url !== undefined) {
+          updatePayload.profile_background_upload_url = profileFields.profile_background_upload_url;
+          updatedFields.push("profile_background_upload_url");
+        }
+        if (profileFields.card_background_upload_url !== undefined) {
+          updatePayload.card_background_upload_url = profileFields.card_background_upload_url;
+          updatedFields.push("card_background_upload_url");
+        }
+
+        // Fail fast if nothing to update
+        if (Object.keys(updatePayload).length === 0 && upload_id === undefined) {
+          return jsonError("At least one field or upload_id is required");
+        }
+
+        let userResponse: any = null;
+        let avatarUpdated = false;
+        let avatarError: string | undefined;
+
+        // Update profile fields if any were provided
+        if (Object.keys(updatePayload).length > 0) {
+          userResponse = await client.put(
+            `/u/${encodeURIComponent(username)}.json`,
+            updatePayload
+          ) as any;
+        }
+
+        // Set avatar if upload_id was provided
+        if (upload_id !== undefined) {
+          try {
+            await rateLimit("user");
+            await client.put(
+              `/u/${encodeURIComponent(username)}/preferences/avatar/pick.json`,
+              { upload_id, type: "uploaded" }
+            );
+            avatarUpdated = true;
+            updatedFields.push("avatar");
+          } catch (e: any) {
+            avatarError = e?.message || String(e);
+            ctx.logger.error(`Failed to set avatar for user ${username}: ${avatarError}`);
+          }
+        }
+
+        // Fetch user data if we didn't already get it from update
+        if (!userResponse?.user) {
+          userResponse = await client.get(`/u/${encodeURIComponent(username)}.json`) as any;
+        }
+
+        const user = userResponse?.user || {};
+
+        const result: Record<string, unknown> = {
+          success: true,
+          username,
+          updated_fields: updatedFields,
+          avatar_updated: avatarUpdated,
+          user: {
+            id: user.id,
+            username: user.username,
+            name: user.name || null,
+            bio_raw: user.bio_raw || null,
+            location: user.location || null,
+            website: user.website || null,
+            title: user.title || null,
+            trust_level: user.trust_level ?? 0,
+            admin: user.admin ?? false,
+            moderator: user.moderator ?? false,
+          },
+        };
+        if (avatarError) {
+          result.avatar_error = avatarError;
+        }
+        return jsonResponse(result);
+      } catch (e: any) {
+        const details: Record<string, unknown> = {};
+        if (e?.body) details.body = e.body;
+        if (e?.status) details.status = e.status;
+        return jsonError(`Failed to update user: ${e?.message || String(e)}`, Object.keys(details).length > 0 ? details : undefined);
+      }
+    }
+  );
+};

--- a/src/tools/builtin/upload_file.ts
+++ b/src/tools/builtin/upload_file.ts
@@ -1,0 +1,202 @@
+import { z } from "zod";
+import { readFile, realpath } from "node:fs/promises";
+import { basename, isAbsolute, normalize } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { RegisterFn } from "../types.js";
+import { jsonResponse, jsonError, rateLimit } from "../../util/json_response.js";
+
+// Upload types that require user_id
+const USER_REQUIRED_TYPES = ["avatar", "profile_background", "card_background"];
+
+// Common MIME types for image uploads
+const MIME_TYPES: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  svg: "image/svg+xml",
+};
+
+/**
+ * Infer MIME type from filename extension or data URI.
+ * @param filename - The filename to extract extension from
+ * @param dataUriMime - Optional MIME type from a data URI (takes precedence)
+ * @returns The inferred MIME type or "application/octet-stream" as fallback
+ */
+function inferMimeType(filename: string, dataUriMime?: string): string {
+  if (dataUriMime) return dataUriMime;
+  const ext = filename.split(".").pop()?.toLowerCase();
+  return (ext && MIME_TYPES[ext]) || "application/octet-stream";
+}
+
+export const registerUploadFile: RegisterFn = (server, ctx, opts) => {
+  if (!opts?.allowWrites) return;
+
+  const schema = z.object({
+    upload_type: z.enum(["avatar", "profile_background", "card_background", "composer"])
+      .describe("Type of upload"),
+    image_data: z.string().optional().describe("Base64 image data (with or without data URI prefix)"),
+    url: z.string().optional().describe("Remote HTTP(S) URL for Discourse to fetch, or file:// URL / absolute local path"),
+    filename: z.string().optional().describe("Filename (required with image_data, optional for file paths)"),
+    user_id: z.number().int().positive().optional().describe("User ID (required for avatar/profile_background/card_background uploads)"),
+  });
+
+  server.registerTool(
+    "discourse_upload_file",
+    {
+      title: "Upload File",
+      description: "Upload an image or file to Discourse. Provide either: image_data (base64 with filename), a remote HTTP(S) URL, or an absolute local file path. user_id is required for avatar/background uploads. Returns upload_id for use in avatar/profile updates. Use short_url to embed images in posts.",
+      inputSchema: schema.shape,
+    },
+    async (args: z.infer<typeof schema>, _extra: any) => {
+      try {
+        // Validate: must provide either image_data OR url, not both or neither
+        const hasImageData = !!args.image_data;
+        const hasUrl = !!args.url;
+        if (hasImageData === hasUrl) {
+          return jsonError("Must provide either image_data OR url, not both or neither");
+        }
+        if (hasImageData && !args.filename) {
+          return jsonError("filename is required when using image_data");
+        }
+
+        // Validate: user_id required for avatar/background uploads
+        if (USER_REQUIRED_TYPES.includes(args.upload_type) && args.user_id === undefined) {
+          return jsonError(`user_id is required for ${args.upload_type} uploads`);
+        }
+
+        // Validate URL scheme if provided and extract local file path if applicable
+        let localFilePath: string | null = null;
+
+        if (args.url) {
+          // Try parsing as URL first
+          let parsedUrl: URL | null = null;
+          try {
+            parsedUrl = new URL(args.url);
+          } catch {
+            // Not a valid URL - might be a plain file path
+          }
+
+          if (parsedUrl) {
+            const scheme = parsedUrl.protocol.replace(":", "").toLowerCase();
+            if (scheme === "http" || scheme === "https") {
+              // Remote URL - will be handled by Discourse
+            } else if (scheme === "file") {
+              // File URL - convert to path using proper decoder
+              try {
+                localFilePath = fileURLToPath(parsedUrl);
+              } catch (e: any) {
+                return jsonError(`Invalid file URL: ${e?.message || String(e)}`);
+              }
+            } else {
+              return jsonError(`Unsupported URL scheme: ${scheme}. Use http(s) or file://`);
+            }
+          } else {
+            // Plain path (not a URL) - must be absolute
+            if (!isAbsolute(args.url)) {
+              return jsonError("Local file path must be absolute");
+            }
+            localFilePath = args.url;
+          }
+
+          // Validate local file paths against allowlist
+          if (localFilePath) {
+            if (!isAbsolute(localFilePath)) {
+              return jsonError("Local file path must be absolute");
+            }
+
+            // Check against allowlist
+            const allowedPaths = ctx.allowedUploadPaths || [];
+            if (allowedPaths.length === 0) {
+              return jsonError("Local file uploads are disabled. Configure --allowed_upload_paths to enable.");
+            }
+
+            // Resolve symlinks to get the real path (prevents symlink escapes)
+            let resolvedPath: string;
+            try {
+              resolvedPath = await realpath(localFilePath);
+            } catch (e: any) {
+              return jsonError(`Cannot access file: ${e?.message || String(e)}`);
+            }
+
+            // Resolve allowed directories too (they might contain symlinks)
+            const resolvedAllowedPaths: string[] = [];
+            for (const allowedDir of allowedPaths) {
+              try {
+                resolvedAllowedPaths.push(await realpath(allowedDir));
+              } catch {
+                // Skip non-existent allowed paths
+                resolvedAllowedPaths.push(normalize(allowedDir));
+              }
+            }
+
+            const isAllowed = resolvedAllowedPaths.some(allowedDir => {
+              return resolvedPath === allowedDir || resolvedPath.startsWith(allowedDir + "/");
+            });
+
+            if (!isAllowed) {
+              return jsonError(`File path not in allowed directories. Allowed: ${allowedPaths.join(", ")}`);
+            }
+          }
+        }
+
+        await rateLimit("upload");
+        const { client } = ctx.siteState.ensureSelectedSite();
+
+        const formData = new FormData();
+        formData.set("type", args.upload_type);
+
+        if (args.user_id !== undefined) {
+          formData.set("user_id", String(args.user_id));
+        }
+
+        if (args.url && !localFilePath) {
+          // Remote URL upload - Discourse will fetch it
+          formData.set("url", args.url);
+        } else if (localFilePath) {
+          // Local file - read and upload
+          const fileData = await readFile(localFilePath);
+          const filename = args.filename || basename(localFilePath);
+          const mimeType = inferMimeType(filename);
+
+          const blob = new Blob([new Uint8Array(fileData)], { type: mimeType });
+          formData.set("file", blob, filename);
+        } else if (args.image_data && args.filename) {
+          // Base64 upload - convert to Blob
+          let base64Data = args.image_data;
+          let dataUriMime: string | undefined;
+
+          // Handle data URI prefix if present
+          const dataUriMatch = base64Data.match(/^data:([^;]+);base64,(.+)$/);
+          if (dataUriMatch) {
+            dataUriMime = dataUriMatch[1];
+            base64Data = dataUriMatch[2];
+          }
+
+          const mimeType = inferMimeType(args.filename, dataUriMime);
+          const binaryData = Buffer.from(base64Data, "base64");
+          const blob = new Blob([binaryData], { type: mimeType });
+          formData.set("file", blob, args.filename);
+        }
+
+        const response = await client.postMultipart("/uploads.json", formData) as any;
+
+        return jsonResponse({
+          id: response.id,
+          url: response.url,
+          short_url: response.short_url,
+          short_path: response.short_path,
+          original_filename: response.original_filename,
+          extension: response.extension,
+          width: response.width,
+          height: response.height,
+          filesize: response.filesize,
+          human_filesize: response.human_filesize,
+        });
+      } catch (e: any) {
+        return jsonError(`Failed to upload file: ${e?.message || String(e)}`);
+      }
+    }
+  );
+};

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -12,6 +12,9 @@ import { registerSelectSite } from "./builtin/select_site.js";
 import { registerFilterTopics } from "./builtin/filter_topics.js";
 import { registerCreateUser } from "./builtin/create_user.js";
 import { registerListUserPosts } from "./builtin/list_user_posts.js";
+import { registerListUsers } from "./builtin/list_users.js";
+import { registerUpdateUser } from "./builtin/update_user.js";
+import { registerUploadFile } from "./builtin/upload_file.js";
 import { registerGetChatMessages } from "./builtin/get_chat_messages.js";
 import {
   registerGetDraft,
@@ -35,6 +38,10 @@ export interface RegistryOptions {
   hideSelectSite?: boolean;
   // Optional default search prefix to add to all searches
   defaultSearchPrefix?: string;
+  // Allowed directories for local file uploads (if empty/undefined, local uploads are disabled)
+  allowedUploadPaths?: string[];
+  // When true, admin-only tools (e.g., list_users) are registered
+  hasAdminApiKey?: boolean;
 }
 
 export async function registerAllTools(
@@ -43,7 +50,7 @@ export async function registerAllTools(
   logger: Logger,
   opts: RegistryOptions & { maxReadLength?: number }
 ) {
-  const ctx = { siteState, logger, defaultSearchPrefix: opts.defaultSearchPrefix, maxReadLength: opts.maxReadLength ?? 50000 } as const;
+  const ctx = { siteState, logger, defaultSearchPrefix: opts.defaultSearchPrefix, maxReadLength: opts.maxReadLength ?? 50000, allowedUploadPaths: opts.allowedUploadPaths } as const;
 
   // Built-in tools (actions and parameterized queries)
   if (!opts.hideSelectSite) {
@@ -59,6 +66,9 @@ export async function registerAllTools(
   registerReadPost(server, ctx, { allowWrites: false });
   registerGetUser(server, ctx, { allowWrites: false });
   registerListUserPosts(server, ctx, { allowWrites: false });
+  if (opts.hasAdminApiKey) {
+    registerListUsers(server, ctx, { allowWrites: false });
+  }
   registerGetChatMessages(server, ctx, { allowWrites: false });
   registerGetDraft(server, ctx, { allowWrites: false });
   
@@ -67,6 +77,8 @@ export async function registerAllTools(
   registerCreateUser(server, ctx, { allowWrites: opts.allowWrites });
   registerCreateCategory(server, ctx, { allowWrites: opts.allowWrites });
   registerCreateTopic(server, ctx, { allowWrites: opts.allowWrites });
+  registerUpdateUser(server, ctx, { allowWrites: opts.allowWrites });
+  registerUploadFile(server, ctx, { allowWrites: opts.allowWrites });
   registerSaveDraft(server, ctx, { allowWrites: opts.allowWrites });
   registerDeleteDraft(server, ctx, { allowWrites: opts.allowWrites });
 }

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -8,6 +8,8 @@ export interface ToolContext {
   defaultSearchPrefix?: string;
   // Maximum number of characters to include when returning post content
   maxReadLength: number;
+  // Allowed directories for local file uploads (if empty, local uploads are disabled)
+  allowedUploadPaths?: string[];
 }
 
 export type RegisterFn = (server: McpServer, ctx: ToolContext, opts: { allowWrites: boolean; toolsMode?: string }) => void | Promise<void>;


### PR DESCRIPTION
Add comprehensive user management capabilities:
- discourse_list_users: Query and filter users (requires admin API key)
- discourse_update_user: Update user profiles with avatar support
- discourse_upload_file: Upload images via base64, URL, or local file

Enhance existing tools:
- discourse_create_user now accepts upload_id for avatar setting

HTTP client improvements:
- Add PUT method support for profile updates
- Add postMultipart for form data uploads with proper boundary handling
- Implement requestMultipart with full error handling and retry logic

All new write tools respect the existing write safety model and rate
limiting. File uploads support multiple sources (base64, remote URL,
local file path) and return short_url for embedding in posts.
