### PR TITLE
FEAT: Send user email if admin access is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The server registers tools under the MCP server name `@discourse/mcp`. Choose a 
     - `info`: Shows retry attempts and general operational messages
     - `error`: Shows only errors
     - `silent`: No logging output
+  - `--show_emails` (default: false). includes emails in user tools. Requires admin access
   - `--tools_mode <auto|discourse_api_only|tool_exec_api>` (default: auto)
   - `--site <url>`: Tether MCP to a single site and hide `discourse_select_site`.
   - `--default-search <prefix>`: Unconditionally prefix every search query (e.g., `tag:ai order:latest`).
@@ -118,6 +119,7 @@ The server registers tools under the MCP server name `@discourse/mcp`. Choose a 
   ],
   "read_only": false,
   "allow_writes": true,
+  "show_emails": true,
   "log_level": "info",
   "tools_mode": "auto",
   "site": "https://try.discourse.org",

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ const ProfileSchema = z
     concurrency: z.number().int().positive().optional().default(4),
     cache_dir: z.string().optional(),
     log_level: z.enum(["silent", "error", "info", "debug"]).optional().default("info"),
+    show_emails: z.boolean().optional().default(false),
     tools_mode: z.enum(["auto", "discourse_api_only", "tool_exec_api"]).optional().default("auto"),
     site: z.string().url().optional().describe("Tether MCP to a single Discourse site; hides select_site and preselects this site"),
     default_search: z.string().optional().describe("Optional search prefix added to every search query (set via --default-search)"),
@@ -138,6 +139,7 @@ function mergeConfig(profile: Partial<Profile>, flags: Record<string, unknown>):
     concurrency: (flags.concurrency as number | undefined) ?? profile.concurrency ?? 4,
     cache_dir: ((flags.cache_dir ?? flags["cache-dir"]) as string | undefined) ?? profile.cache_dir,
     log_level: (((flags.log_level ?? flags["log-level"]) as LogLevel | undefined) ?? (profile.log_level as LogLevel | undefined) ?? "info") as LogLevel,
+    show_emails: (((flags.show_emails ?? flags["show-emails"]) as boolean | undefined) ?? (profile.show_emails as boolean | undefined) ?? false) as boolean,
     tools_mode: (((flags.tools_mode ?? flags["tools-mode"]) as ToolsMode | undefined) ?? (profile.tools_mode as ToolsMode | undefined) ?? "auto") as ToolsMode,
     site: (flags.site as string | undefined) ?? profile.site,
     default_search: (((flags.default_search ?? flags["default-search"]) as string | undefined) ?? profile.default_search) as string | undefined,
@@ -225,6 +227,7 @@ async function main() {
   );
 
   const allowWrites = Boolean(config.allow_writes && !config.read_only);
+  const showEmails = Boolean(config.show_emails);
   const allowAdminTools = siteState.hasAdminAuth();
 
   // If tethered to a site, validate and preselect it before registering tools,
@@ -251,6 +254,7 @@ async function main() {
     defaultSearchPrefix: config.default_search,
     maxReadLength: config.max_read_length,
     allowedUploadPaths: config.allowed_upload_paths,
+    showEmails
   });
 
   // Register MCP resources (URI-addressable read-only data)

--- a/src/tools/builtin/get_user.ts
+++ b/src/tools/builtin/get_user.ts
@@ -3,7 +3,7 @@ import type { RegisterFn } from "../types.js";
 import { jsonResponse, jsonError } from "../../util/json_response.js";
 import { requireAdminAccess } from "../../util/access.js";
 
-export const registerGetUser: RegisterFn = (server, ctx) => {
+export const registerGetUser: RegisterFn = (server, ctx, opts) => {
   const schema = z.object({
     username: z.string().min(1),
   });
@@ -35,7 +35,7 @@ export const registerGetUser: RegisterFn = (server, ctx) => {
 
         const hasAdminAccess = !requireAdminAccess(ctx.siteState);
 
-        if (hasAdminAccess) {
+        if (hasAdminAccess && opts.showEmails) {
           const emailData = (await client.get(`/u/${encodeURIComponent(username)}/emails.json`)) as any;
           response.email = emailData?.email || null;
         }

--- a/src/tools/builtin/get_user.ts
+++ b/src/tools/builtin/get_user.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { RegisterFn } from "../types.js";
 import { jsonResponse, jsonError } from "../../util/json_response.js";
+import { requireAdminAccess } from "../../util/access.js";
 
 export const registerGetUser: RegisterFn = (server, ctx) => {
   const schema = z.object({
@@ -20,7 +21,7 @@ export const registerGetUser: RegisterFn = (server, ctx) => {
         const data = (await client.get(`/u/${encodeURIComponent(username)}.json`)) as any;
         const user = data?.user || data;
 
-        return jsonResponse({
+        const response = {
           id: user?.id,
           username: user?.username || username,
           name: user?.name || null,
@@ -29,7 +30,18 @@ export const registerGetUser: RegisterFn = (server, ctx) => {
           bio: user?.bio_raw ? user.bio_raw.slice(0, 500) : null,
           admin: user?.admin || false,
           moderator: user?.moderator || false,
-        });
+          email: undefined
+        }
+
+        const hasAdminAccess = !requireAdminAccess(ctx.siteState);
+
+        if (hasAdminAccess) {
+          const emailData = (await client.get(`/u/${encodeURIComponent(username)}/emails.json`)) as any;
+          response.email = emailData?.email || null;
+        }
+
+
+        return jsonResponse(response);
       } catch (e: any) {
         return jsonError(`Failed to get user ${username}: ${e?.message || String(e)}`);
       }

--- a/src/tools/builtin/list_users.ts
+++ b/src/tools/builtin/list_users.ts
@@ -19,6 +19,7 @@ export const registerListUsers: RegisterFn = (server, ctx, opts) => {
       .optional()
       .describe("Sort order field"),
     asc: z.boolean().optional().default(false).describe("Sort ascending (default: false/descending)"),
+    show_emails: z.boolean().optional().default(false).describe("Whether to include email addresses in the response"),
     page: z.number().int().min(0).optional().describe("Page number (0-indexed)"),
   });
 
@@ -46,6 +47,7 @@ export const registerListUsers: RegisterFn = (server, ctx, opts) => {
         if (args.filter) params.set("filter", args.filter);
         if (args.order) params.set("order", args.order);
         if (args.asc) params.set("asc", "true");
+        if (args.show_emails) params.set("show_emails", "true");
 
         const data = (await client.get(
           `/admin/users/list/${query}.json?${params.toString()}`

--- a/src/tools/builtin/list_users.ts
+++ b/src/tools/builtin/list_users.ts
@@ -19,7 +19,6 @@ export const registerListUsers: RegisterFn = (server, ctx, opts) => {
       .optional()
       .describe("Sort order field"),
     asc: z.boolean().optional().default(false).describe("Sort ascending (default: false/descending)"),
-    show_emails: z.boolean().optional().default(false).describe("Whether to include email addresses in the response"),
     page: z.number().int().min(0).optional().describe("Page number (0-indexed)"),
   });
 
@@ -47,7 +46,7 @@ export const registerListUsers: RegisterFn = (server, ctx, opts) => {
         if (args.filter) params.set("filter", args.filter);
         if (args.order) params.set("order", args.order);
         if (args.asc) params.set("asc", "true");
-        if (args.show_emails) params.set("show_emails", "true");
+        if (opts.showEmails) params.set("show_emails", "true");
 
         const data = (await client.get(
           `/admin/users/list/${query}.json?${params.toString()}`

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -43,6 +43,8 @@ export interface RegistryOptions {
   defaultSearchPrefix?: string;
   // Allowed directories for local file uploads (if empty/undefined, local uploads are disabled)
   allowedUploadPaths?: string[];
+  // When true, include email addresses in user information
+  showEmails?: boolean;
 }
 
 export async function registerAllTools(
@@ -65,9 +67,9 @@ export async function registerAllTools(
   // Read tools (parameterized lookups)
   registerReadTopic(server, ctx, { allowWrites: false });
   registerReadPost(server, ctx, { allowWrites: false });
-  registerGetUser(server, ctx, { allowWrites: false });
+  registerGetUser(server, ctx, { allowWrites: false, showEmails: opts.showEmails });
   registerListUserPosts(server, ctx, { allowWrites: false });
-  registerListUsers(server, ctx, { allowWrites: false, allowAdminTools: opts.allowAdminTools });
+  registerListUsers(server, ctx, { allowWrites: false, allowAdminTools: opts.allowAdminTools, showEmails: opts.showEmails });
   registerGetChatMessages(server, ctx, { allowWrites: false });
   registerGetDraft(server, ctx, { allowWrites: false });
   

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -15,5 +15,5 @@ export interface ToolContext {
   allowedUploadPaths?: string[];
 }
 
-export type RegisterFn = (server: ToolRegistrar, ctx: ToolContext, opts: { allowWrites: boolean; allowAdminTools?: boolean; toolsMode?: string }) => void | Promise<void>;
+export type RegisterFn = (server: ToolRegistrar, ctx: ToolContext, opts: { allowWrites: boolean; allowAdminTools?: boolean; toolsMode?: string, showEmails?: boolean }) => void | Promise<void>;
 


### PR DESCRIPTION
Email addresses can be useful for admins when attempting to identify existing customers, analytics of companies active in the community, non-admin/non-mod employees being helpful to the community, etc.

It would be helpful if the MCP was able to provide email addresses when Admin access is available in order to figure these things out.

Hence, this PR.