### PR TITLE
FIX: expand ~ in profile paths before reading file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.5](https://github.com/discourse/discourse-mcp/compare/v0.2.4...v0.2.5) (2026-01-29)
+
+### Bug Fixes
+
+* Expand `~` in `--profile` paths before reading file
+
 ## [0.2.4](https://github.com/discourse/discourse-mcp/compare/v0.2.3...v0.2.4) (2026-01-20)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@discourse/mcp",
   "mcpName": "io.github.discourse/mcp",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Discourse MCP CLI server (stdio) exposing Discourse tools via MCP",
   "author": "Discourse",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { readFile } from "node:fs/promises";
 import { createServer } from "node:http";
+import { homedir } from "node:os";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
@@ -82,7 +83,8 @@ type Profile = z.infer<typeof ProfileSchema>;
 
 async function loadProfile(path?: string): Promise<Partial<Profile>> {
   if (!path) return {};
-  const txt = await readFile(path, "utf8");
+  const resolved = path.replace(/^~(?=$|\/)/, homedir());
+  const txt = await readFile(resolved, "utf8");
   const raw = JSON.parse(txt);
   const parsed = ProfileSchema.partial().safeParse(raw);
   if (!parsed.success) throw new Error(`Invalid profile JSON: ${parsed.error.message}`);


### PR DESCRIPTION
When passing --profile ~/.mcps/foo.json, the shell does not expand `~` if the argument is quoted or passed programmatically (e.g. from Claude config). This PR resolves `~` at the start of the path so profile loading works regardless of how the argument arrives.


## before fix

```
➜  discourse-mcp git:(main) pnpm build && node dist/index.js --profile '~/.mcps/d-derp.json'
 
> @discourse/mcp@0.2.4 build /Users/derp/work/discourse/discourse-mcp
> tsc -p tsconfig.json

[2026-01-28T09:33:27.781Z] ERROR Failed to load profile: ENOENT: no such file or directory, open '~/.mcps/d-derp.json'
```

## after fix

```
➜  discourse-mcp git:(fix-tilde-profile-path) pnpm build && node dist/index.js --profile '~/.mcps/d-derp.json'
 
> @discourse/mcp@0.2.4 build /Users/derp/work/discourse/discourse-mcp
> tsc -p tsconfig.json

[2026-01-28T09:33:51.077Z] INFO Starting Discourse MCP v0.2.4
```