### PR TITLE
fix: always register admin tools and allow user API key auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.2.6](https://github.com/discourse/discourse-mcp/compare/v0.2.5...v0.2.6) (2026-03-04)
+
+### Bug Fixes
+
+* Always register Data Explorer tools, resources, and prompts regardless of auth type
+  - `prompts/list` no longer errors or returns empty for non-admin users
+  - Admin access is now enforced at call time by Discourse, not at registration time
+* Allow user API key auth for admin-only endpoints (Data Explorer, list_users)
+  - Previously only global API keys were accepted; admin users with user API keys were blocked
+  - Discourse enforces actual admin permissions server-side
+
 ## [0.2.5](https://github.com/discourse/discourse-mcp/compare/v0.2.4...v0.2.5) (2026-02-03)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@discourse/mcp",
   "mcpName": "io.github.discourse/mcp",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Discourse MCP CLI server (stdio) exposing Discourse tools via MCP",
   "author": "Discourse",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -230,7 +230,6 @@ async function main() {
 
   const allowWrites = Boolean(config.allow_writes && !config.read_only);
   const showEmails = Boolean(config.show_emails);
-  const allowAdminTools = siteState.hasAdminAuth();
 
   // If tethered to a site, validate and preselect it before registering tools,
   // and trigger remote tool discovery when enabled.
@@ -250,7 +249,6 @@ async function main() {
 
   await registerAllTools(server, siteState, logger, {
     allowWrites,
-    allowAdminTools,
     toolsMode: config.tools_mode,
     hideSelectSite,
     defaultSearchPrefix: config.default_search,
@@ -260,10 +258,10 @@ async function main() {
   });
 
   // Register MCP resources (URI-addressable read-only data)
-  registerAllResources(server, { siteState, logger, allowAdminTools });
+  registerAllResources(server, { siteState, logger });
 
   // Register MCP prompts (guided workflows)
-  registerAllPrompts(server, { siteState, logger, allowAdminTools });
+  registerAllPrompts(server, { siteState, logger });
 
   // If tethered and remote tool discovery is enabled, discover now
   if (config.site && config.tools_mode !== "discourse_api_only") {

--- a/src/prompts/registry.ts
+++ b/src/prompts/registry.ts
@@ -19,7 +19,6 @@ export type PromptRegistrar = Pick<McpServer, "registerPrompt">;
 export interface PromptContext {
   siteState: SiteState;
   logger: Logger;
-  allowAdminTools?: boolean;
 }
 
 /**
@@ -29,12 +28,8 @@ export function registerAllPrompts(
   server: PromptRegistrar,
   ctx: PromptContext
 ): void {
-  // Only register SQL query prompt if admin tools allowed
-  // Default to computed auth if not explicitly provided
-  const allowAdminTools = ctx.allowAdminTools ?? ctx.siteState.hasAdminAuth();
-  if (allowAdminTools) {
-    registerSqlQueryPrompt(server, ctx);
-  }
+  // Always register prompts; access is enforced at tool call time by Discourse
+  registerSqlQueryPrompt(server, ctx);
 }
 
 function registerSqlQueryPrompt(

--- a/src/resources/registry.ts
+++ b/src/resources/registry.ts
@@ -34,7 +34,6 @@ export type ResourceRegistrar = Pick<McpServer, "resource">;
 export interface ResourceContext {
   siteState: SiteState;
   logger: Logger;
-  allowAdminTools?: boolean;
 }
 
 /**
@@ -52,13 +51,9 @@ export function registerAllResources(
   registerUserChatChannelsResource(server, ctx);
   registerUserDraftsResource(server, ctx);
 
-  // Only register Data Explorer resources if admin tools allowed
-  // Default to computed auth if not explicitly provided
-  const allowAdminTools = ctx.allowAdminTools ?? ctx.siteState.hasAdminAuth();
-  if (allowAdminTools) {
-    registerExplorerSchemaResource(server, ctx);
-    registerExplorerQueriesResource(server, ctx);
-  }
+  // Data Explorer resources are always registered; access is checked at call time
+  registerExplorerSchemaResource(server, ctx);
+  registerExplorerQueriesResource(server, ctx);
 }
 
 /**

--- a/src/site/state.ts
+++ b/src/site/state.ts
@@ -108,14 +108,6 @@ export class SiteState {
     }
   }
 
-  /**
-   * Check if any configured site has admin-level auth (api_key).
-   * Used to determine whether to expose admin-only tools.
-   */
-  hasAdminAuth(): boolean {
-    if (this.opts.defaultAuth.type === "api_key") return true;
-    return (this.opts.authOverrides || []).some((o) => !!o.api_key);
-  }
 }
 
 export type SiteStateInit = ConstructorParameters<typeof SiteState>[0];

--- a/src/test/tools.test.ts
+++ b/src/test/tools.test.ts
@@ -233,7 +233,8 @@ const READ_ONLY_TOOLS = [
   'discourse_get_draft',
 ];
 
-const ADMIN_TOOLS = [
+// Admin-only tools are now always registered; access is checked at call time
+const ADMIN_READ_TOOLS = [
   'discourse_list_users',
   'discourse_get_query',
   'discourse_run_query',
@@ -249,75 +250,38 @@ const WRITE_TOOLS = [
   'discourse_upload_file',
   'discourse_save_draft',
   'discourse_delete_draft',
-];
-
-const ADMIN_WRITE_TOOLS = [
   'discourse_create_query',
   'discourse_update_query',
   'discourse_delete_query',
 ];
 
-test('read-only mode without admin auth exposes only read tools', async () => {
+test('read-only mode registers read + admin-read tools (access checked at call time)', async () => {
   const logger = new Logger('silent');
   const siteState = new SiteState({ logger, timeoutMs: 5000, defaultAuth: { type: 'none' } });
   const { server, tools } = createMockServer();
 
   await registerAllTools(server, siteState, logger, {
     allowWrites: false,
-    allowAdminTools: false,
     toolsMode: 'discourse_api_only'
   });
 
   const registeredTools = Object.keys(tools).sort();
-  const expectedTools = [...READ_ONLY_TOOLS].sort();
+  const expectedTools = [...READ_ONLY_TOOLS, ...ADMIN_READ_TOOLS].sort();
   assert.deepEqual(registeredTools, expectedTools);
 });
 
-test('read-only mode with admin auth exposes read + admin tools', async () => {
+test('write mode registers all tools', async () => {
   const logger = new Logger('silent');
-  const siteState = new SiteState({ logger, timeoutMs: 5000, defaultAuth: { type: 'api_key', key: 'test' } });
-  const { server, tools } = createMockServer();
-
-  await registerAllTools(server, siteState, logger, {
-    allowWrites: false,
-    allowAdminTools: true,
-    toolsMode: 'discourse_api_only'
-  });
-
-  const registeredTools = Object.keys(tools).sort();
-  const expectedTools = [...READ_ONLY_TOOLS, ...ADMIN_TOOLS].sort();
-  assert.deepEqual(registeredTools, expectedTools);
-});
-
-test('write mode with admin auth exposes all tools', async () => {
-  const logger = new Logger('silent');
-  const siteState = new SiteState({ logger, timeoutMs: 5000, defaultAuth: { type: 'api_key', key: 'test' } });
+  const siteState = new SiteState({ logger, timeoutMs: 5000, defaultAuth: { type: 'none' } });
   const { server, tools } = createMockServer();
 
   await registerAllTools(server, siteState, logger, {
     allowWrites: true,
-    allowAdminTools: true,
     toolsMode: 'discourse_api_only'
   });
 
   const registeredTools = Object.keys(tools).sort();
-  const expectedTools = [...READ_ONLY_TOOLS, ...ADMIN_TOOLS, ...WRITE_TOOLS, ...ADMIN_WRITE_TOOLS].sort();
-  assert.deepEqual(registeredTools, expectedTools);
-});
-
-test('write mode without admin auth exposes read + write but not admin tools', async () => {
-  const logger = new Logger('silent');
-  const siteState = new SiteState({ logger, timeoutMs: 5000, defaultAuth: { type: 'user_api_key', key: 'test' } });
-  const { server, tools } = createMockServer();
-
-  await registerAllTools(server, siteState, logger, {
-    allowWrites: true,
-    allowAdminTools: false,
-    toolsMode: 'discourse_api_only'
-  });
-
-  const registeredTools = Object.keys(tools).sort();
-  const expectedTools = [...READ_ONLY_TOOLS, ...WRITE_TOOLS].sort();
+  const expectedTools = [...READ_ONLY_TOOLS, ...ADMIN_READ_TOOLS, ...WRITE_TOOLS].sort();
   assert.deepEqual(registeredTools, expectedTools);
 });
 
@@ -328,58 +292,15 @@ test('tethered mode hides select_site from tool list', async () => {
 
   await registerAllTools(server, siteState, logger, {
     allowWrites: false,
-    allowAdminTools: false,
     toolsMode: 'discourse_api_only',
     hideSelectSite: true
   });
 
   const registeredTools = Object.keys(tools).sort();
-  const expectedTools = READ_ONLY_TOOLS.filter(t => t !== 'discourse_select_site').sort();
+  const expectedTools = [...READ_ONLY_TOOLS, ...ADMIN_READ_TOOLS].filter(t => t !== 'discourse_select_site').sort();
   assert.deepEqual(registeredTools, expectedTools);
 });
 
-// SiteState.hasAdminAuth() tests
-test('SiteState.hasAdminAuth returns true when api_key in defaultAuth', async () => {
-  const logger = new Logger('silent');
-  const siteState = new SiteState({
-    logger,
-    timeoutMs: 5000,
-    defaultAuth: { type: 'api_key', key: 'admin-key' }
-  });
-  assert.ok(siteState.hasAdminAuth());
-});
-
-test('SiteState.hasAdminAuth returns true when api_key in authOverrides', async () => {
-  const logger = new Logger('silent');
-  const siteState = new SiteState({
-    logger,
-    timeoutMs: 5000,
-    defaultAuth: { type: 'none' },
-    authOverrides: [{ site: 'https://admin.example.com', api_key: 'admin-key' }]
-  });
-  assert.ok(siteState.hasAdminAuth());
-});
-
-test('SiteState.hasAdminAuth returns false with only user_api_key', async () => {
-  const logger = new Logger('silent');
-  const siteState = new SiteState({
-    logger,
-    timeoutMs: 5000,
-    defaultAuth: { type: 'none' },
-    authOverrides: [{ site: 'https://site.example.com', user_api_key: 'user-key' }]
-  });
-  assert.ok(!siteState.hasAdminAuth());
-});
-
-test('SiteState.hasAdminAuth returns false with no auth', async () => {
-  const logger = new Logger('silent');
-  const siteState = new SiteState({
-    logger,
-    timeoutMs: 5000,
-    defaultAuth: { type: 'none' }
-  });
-  assert.ok(!siteState.hasAdminAuth());
-});
 
 // ========================
 // Resource registration tests - verify resources are exposed based on auth context
@@ -412,24 +333,12 @@ function createMockResourceServer(): { server: ResourceRegistrar; resources: Rec
   return { server, resources };
 }
 
-test('resources without admin auth excludes Data Explorer resources', async () => {
+test('resources always includes Data Explorer resources regardless of auth', async () => {
   const logger = new Logger('silent');
   const siteState = new SiteState({ logger, timeoutMs: 5000, defaultAuth: { type: 'none' } });
   const { server, resources } = createMockResourceServer();
 
-  registerAllResources(server, { siteState, logger, allowAdminTools: false });
-
-  const registeredResources = Object.keys(resources).sort();
-  const expectedResources = [...BASE_RESOURCES].sort();
-  assert.deepEqual(registeredResources, expectedResources);
-});
-
-test('resources with admin auth includes Data Explorer resources', async () => {
-  const logger = new Logger('silent');
-  const siteState = new SiteState({ logger, timeoutMs: 5000, defaultAuth: { type: 'api_key', key: 'test' } });
-  const { server, resources } = createMockResourceServer();
-
-  registerAllResources(server, { siteState, logger, allowAdminTools: true });
+  registerAllResources(server, { siteState, logger });
 
   const registeredResources = Object.keys(resources).sort();
   const expectedResources = [...BASE_RESOURCES, ...ADMIN_RESOURCES].sort();
@@ -451,22 +360,12 @@ function createMockPromptServer(): { server: PromptRegistrar; prompts: Record<st
   return { server, prompts };
 }
 
-test('prompts without admin auth excludes sql_query prompt', async () => {
+test('prompts always includes sql_query prompt regardless of auth', async () => {
   const logger = new Logger('silent');
   const siteState = new SiteState({ logger, timeoutMs: 5000, defaultAuth: { type: 'none' } });
   const { server, prompts } = createMockPromptServer();
 
-  registerAllPrompts(server, { siteState, logger, allowAdminTools: false });
-
-  assert.deepEqual(Object.keys(prompts), []);
-});
-
-test('prompts with admin auth includes sql_query prompt', async () => {
-  const logger = new Logger('silent');
-  const siteState = new SiteState({ logger, timeoutMs: 5000, defaultAuth: { type: 'api_key', key: 'test' } });
-  const { server, prompts } = createMockPromptServer();
-
-  registerAllPrompts(server, { siteState, logger, allowAdminTools: true });
+  registerAllPrompts(server, { siteState, logger });
 
   assert.deepEqual(Object.keys(prompts), ['sql_query']);
 });

--- a/src/tools/builtin/data_explorer/create_query.ts
+++ b/src/tools/builtin/data_explorer/create_query.ts
@@ -11,7 +11,7 @@ import {
 import { requireAdminAccess } from "../../../util/access.js";
 
 export const registerCreateQuery: RegisterFn = (server, ctx, opts) => {
-  if (!opts.allowAdminTools || !opts.allowWrites) return;
+  if (!opts.allowWrites) return;
 
   const schema = z.object({
     name: z

--- a/src/tools/builtin/data_explorer/delete_query.ts
+++ b/src/tools/builtin/data_explorer/delete_query.ts
@@ -10,7 +10,7 @@ import {
 import { requireAdminAccess } from "../../../util/access.js";
 
 export const registerDeleteQuery: RegisterFn = (server, ctx, opts) => {
-  if (!opts.allowAdminTools || !opts.allowWrites) return;
+  if (!opts.allowWrites) return;
 
   const schema = z.object({
     id: z.number().int().positive().describe("Query ID to delete"),

--- a/src/tools/builtin/data_explorer/get_query.ts
+++ b/src/tools/builtin/data_explorer/get_query.ts
@@ -9,8 +9,7 @@ import {
 } from "../../../util/json_response.js";
 import { requireAdminAccess } from "../../../util/access.js";
 
-export const registerGetQuery: RegisterFn = (server, ctx, opts) => {
-  if (!opts.allowAdminTools) return;
+export const registerGetQuery: RegisterFn = (server, ctx, _opts) => {
   const schema = z.object({
     id: z.number().int().positive().describe("Query ID"),
   });

--- a/src/tools/builtin/data_explorer/run_query.ts
+++ b/src/tools/builtin/data_explorer/run_query.ts
@@ -10,7 +10,6 @@ import {
 import { requireAdminAccess } from "../../../util/access.js";
 
 export const registerRunQuery: RegisterFn = (server, ctx, opts) => {
-  if (!opts.allowAdminTools) return;
   const schema = z.object({
     id: z.number().int().describe("Query ID to run"),
     params: z

--- a/src/tools/builtin/data_explorer/update_query.ts
+++ b/src/tools/builtin/data_explorer/update_query.ts
@@ -11,7 +11,7 @@ import {
 import { requireAdminAccess } from "../../../util/access.js";
 
 export const registerUpdateQuery: RegisterFn = (server, ctx, opts) => {
-  if (!opts.allowAdminTools || !opts.allowWrites) return;
+  if (!opts.allowWrites) return;
 
   const schema = z.object({
     id: z.number().int().positive().describe("Query ID to update"),

--- a/src/tools/builtin/list_users.ts
+++ b/src/tools/builtin/list_users.ts
@@ -7,8 +7,6 @@ import { requireAdminAccess } from "../../util/access.js";
 const DISCOURSE_PAGE_SIZE = 100;
 
 export const registerListUsers: RegisterFn = (server, ctx, opts) => {
-  // Admin tools require explicit opt-in via allowAdminTools
-  if (!opts?.allowAdminTools) return;
   const schema = z.object({
     query: z.enum(["active", "new", "staff", "suspended", "silenced", "pending", "staged"])
       .optional()

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -41,8 +41,6 @@ export type ToolsMode = "auto" | "discourse_api_only" | "tool_exec_api";
 
 export interface RegistryOptions {
   allowWrites: boolean;
-  // When true, expose admin-only tools (e.g., list_users). Requires api_key auth.
-  allowAdminTools?: boolean;
   toolsMode: ToolsMode;
   // When true, do not register the discourse_select_site tool
   hideSelectSite?: boolean;
@@ -76,7 +74,7 @@ export async function registerAllTools(
   registerReadPost(server, ctx, { allowWrites: false });
   registerGetUser(server, ctx, { allowWrites: false, showEmails: opts.showEmails });
   registerListUserPosts(server, ctx, { allowWrites: false });
-  registerListUsers(server, ctx, { allowWrites: false, allowAdminTools: opts.allowAdminTools, showEmails: opts.showEmails });
+  registerListUsers(server, ctx, { allowWrites: false, showEmails: opts.showEmails });
   registerGetChatMessages(server, ctx, { allowWrites: false });
   registerGetDraft(server, ctx, { allowWrites: false });
   
@@ -91,10 +89,10 @@ export async function registerAllTools(
   registerSaveDraft(server, ctx, { allowWrites: opts.allowWrites });
   registerDeleteDraft(server, ctx, { allowWrites: opts.allowWrites });
 
-  // Data Explorer tools (admin-only)
-  registerGetQuery(server, ctx, { allowWrites: false, allowAdminTools: opts.allowAdminTools });
-  registerRunQuery(server, ctx, { allowWrites: false, allowAdminTools: opts.allowAdminTools });
-  registerCreateQuery(server, ctx, { allowWrites: opts.allowWrites, allowAdminTools: opts.allowAdminTools });
-  registerUpdateQuery(server, ctx, { allowWrites: opts.allowWrites, allowAdminTools: opts.allowAdminTools });
-  registerDeleteQuery(server, ctx, { allowWrites: opts.allowWrites, allowAdminTools: opts.allowAdminTools });
+  // Data Explorer tools (admin access checked at call time)
+  registerGetQuery(server, ctx, { allowWrites: false });
+  registerRunQuery(server, ctx, { allowWrites: false });
+  registerCreateQuery(server, ctx, { allowWrites: opts.allowWrites });
+  registerUpdateQuery(server, ctx, { allowWrites: opts.allowWrites });
+  registerDeleteQuery(server, ctx, { allowWrites: opts.allowWrites });
 }

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -15,5 +15,5 @@ export interface ToolContext {
   allowedUploadPaths?: string[];
 }
 
-export type RegisterFn = (server: ToolRegistrar, ctx: ToolContext, opts: { allowWrites: boolean; allowAdminTools?: boolean; toolsMode?: string, showEmails?: boolean }) => void | Promise<void>;
+export type RegisterFn = (server: ToolRegistrar, ctx: ToolContext, opts: { allowWrites: boolean; toolsMode?: string, showEmails?: boolean }) => void | Promise<void>;
 

--- a/src/util/access.ts
+++ b/src/util/access.ts
@@ -1,7 +1,7 @@
 import type { SiteState } from "../site/state.js";
 import { jsonError } from "./json_response.js";
 
-type AuthRequirement = "any" | "api_key";
+type AuthRequirement = "any" | "admin";
 
 function requireSiteAuth(siteState: SiteState, requirement: AuthRequirement) {
   const base = siteState.getSiteBase();
@@ -16,8 +16,8 @@ function requireSiteAuth(siteState: SiteState, requirement: AuthRequirement) {
     );
   }
 
-  if (requirement === "api_key" && authType !== "api_key") {
-    return jsonError(`Admin API key required for selected site (${base}).`);
+  if (requirement === "admin" && authType !== "api_key" && authType !== "user_api_key") {
+    return jsonError(`Admin API key or admin user API key required for selected site (${base}).`);
   }
 
   return null;
@@ -31,5 +31,5 @@ export function requireWriteAccess(siteState: SiteState, allowWrites: boolean) {
 }
 
 export function requireAdminAccess(siteState: SiteState) {
-  return requireSiteAuth(siteState, "api_key");
+  return requireSiteAuth(siteState, "admin");
 }


### PR DESCRIPTION
- Always register Data Explorer tools, resources, and prompts regardless of auth type — fixes `prompts/list` returning empty/erroring for non-admin users
- Allow `user_api_key` auth for admin-only endpoints (Data Explorer, list_users) — previously only global API keys were accepted, blocking admin users with user API keys
- Access is now enforced at call time by Discourse server-side, not at MCP registration time
- Remove `hasAdminAuth()` and `allowAdminTools` config — no longer needed