### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,3 +456,8 @@ You can also manually create User API Keys via the Discourse UI (if enabled by t
   - Network-level errors (DNS, SSL/TLS, connectivity issues)
   - Retry attempts and timing
   - Timeout diagnostics
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/discourse-discourse-mcp).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/discourse-discourse-mcp).