### PR TITLE
FEATURE: add support for post editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.7](https://github.com/discourse/discourse-mcp/compare/v0.2.6...v0.2.7) (2026-03-31)
+
+### Features
+
+* Add `discourse_update_post` tool to edit existing post content
+  - Update post body via `PUT /posts/:post_id.json`
+  - Optional `edit_reason` parameter for edit history
+
 ## [0.2.6](https://github.com/discourse/discourse-mcp/compare/v0.2.5...v0.2.6) (2026-03-04)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@discourse/mcp",
   "mcpName": "io.github.discourse/mcp",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Discourse MCP CLI server (stdio) exposing Discourse tools via MCP",
   "author": "Discourse",
   "license": "MIT",

--- a/src/test/tools.test.ts
+++ b/src/test/tools.test.ts
@@ -246,6 +246,7 @@ const WRITE_TOOLS = [
   'discourse_create_category',
   'discourse_create_topic',
   'discourse_update_topic',
+  'discourse_update_post',
   'discourse_update_user',
   'discourse_upload_file',
   'discourse_save_draft',

--- a/src/tools/builtin/update_post.ts
+++ b/src/tools/builtin/update_post.ts
@@ -1,0 +1,78 @@
+import { z } from "zod";
+import type { RegisterFn } from "../types.js";
+import { jsonResponse, jsonError, rateLimit, isZodError, zodError } from "../../util/json_response.js";
+import { requireWriteAccess } from "../../util/access.js";
+
+export const registerUpdatePost: RegisterFn = (server, ctx, opts) => {
+  if (!opts?.allowWrites) return;
+
+  const schema = z.object({
+    post_id: z.number().int().positive().describe("Post ID to update"),
+    raw: z.string().min(1).max(30000).describe("New post content (markdown)"),
+    edit_reason: z.string().max(500).optional().describe("Reason for the edit"),
+  });
+
+  server.registerTool(
+    "discourse_update_post",
+    {
+      title: "Update Post",
+      description: "Update the content of an existing post. Returns JSON with updated post details.",
+      inputSchema: schema.shape,
+    },
+    async (args, _extra) => {
+      try {
+        const { post_id, raw, edit_reason } = schema.parse(args);
+
+        const accessError = requireWriteAccess(ctx.siteState, opts.allowWrites);
+        if (accessError) return accessError;
+
+        await rateLimit("post");
+
+        const { client } = ctx.siteState.ensureSelectedSite();
+
+        const payload: Record<string, any> = { post: { raw } };
+        if (edit_reason !== undefined) {
+          payload.post.edit_reason = edit_reason;
+        }
+
+        const data = (await client.put(
+          `/posts/${encodeURIComponent(String(post_id))}.json`,
+          payload
+        )) as any;
+
+        const post = data?.post || data;
+
+        return jsonResponse({
+          id: post.id ?? post_id,
+          topic_id: post.topic_id ?? null,
+          post_number: post.post_number ?? null,
+          raw: post.raw ?? raw,
+          updated_at: post.updated_at ?? null,
+          edit_reason: post.edit_reason ?? edit_reason ?? null,
+        });
+      } catch (e: unknown) {
+        if (isZodError(e)) return zodError(e);
+        const err = e as any;
+        const status = err?.status || err?.response?.status;
+        const body = err?.body || err?.response?.body;
+
+        if (status === 403) {
+          return jsonError("Permission denied: cannot update this post", { status });
+        }
+
+        if (status === 422) {
+          const errors = body?.errors || err?.message;
+          return jsonError(`Validation failed: ${Array.isArray(errors) ? errors.join(", ") : errors}`, {
+            status,
+            body,
+          });
+        }
+
+        const details: Record<string, unknown> = {};
+        if (status) details.status = status;
+        if (body) details.body = body;
+        return jsonError(`Failed to update post: ${err?.message || String(e)}`, Object.keys(details).length > 0 ? details : undefined);
+      }
+    }
+  );
+};

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -9,6 +9,7 @@ import { registerCreatePost } from "./builtin/create_post.js";
 import { registerCreateCategory } from "./builtin/create_category.js";
 import { registerCreateTopic } from "./builtin/create_topic.js";
 import { registerUpdateTopic } from "./builtin/update_topic.js";
+import { registerUpdatePost } from "./builtin/update_post.js";
 import { registerSelectSite } from "./builtin/select_site.js";
 import { registerFilterTopics } from "./builtin/filter_topics.js";
 import { registerCreateUser } from "./builtin/create_user.js";
@@ -84,6 +85,7 @@ export async function registerAllTools(
   registerCreateCategory(server, ctx, { allowWrites: opts.allowWrites });
   registerCreateTopic(server, ctx, { allowWrites: opts.allowWrites });
   registerUpdateTopic(server, ctx, { allowWrites: opts.allowWrites });
+  registerUpdatePost(server, ctx, { allowWrites: opts.allowWrites });
   registerUpdateUser(server, ctx, { allowWrites: opts.allowWrites });
   registerUploadFile(server, ctx, { allowWrites: opts.allowWrites });
   registerSaveDraft(server, ctx, { allowWrites: opts.allowWrites });


### PR DESCRIPTION
## Summary

- Add `discourse_update_post` tool to edit existing post content via `PUT /posts/:post_id.json`
- Supports `post_id`, `raw` (markdown content), and optional `edit_reason` parameters
- Bump version to 0.2.7