### PR TITLE
Add top-level CLI info flags

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,34 @@ import { SiteState, type AuthOverride } from "./site/state.js";
 
 const DEFAULT_TIMEOUT_MS = 15000;
 
+function shouldShowHelp(args: string[]): boolean {
+  return args.includes("--help") || args.includes("-h") || args[0] === "help";
+}
+
+function shouldShowVersion(args: string[]): boolean {
+  return args.includes("--version") || args.includes("-v") || args[0] === "version";
+}
+
+function printHelp(): void {
+  process.stdout.write(`Usage: discourse-mcp [options]
+
+Options:
+  --profile <path>              Load a JSON profile
+  --site <url>                  Tether MCP to a single Discourse site
+  --auth_pairs <json>           Per-site auth configuration
+  --read_only <boolean>         Run in read-only mode (default: true)
+  --allow_writes <boolean>      Enable write tools when read_only is false
+  --transport <stdio|http>      Transport type (default: stdio)
+  --port <number>               HTTP transport port (default: 3000)
+  --log_level <level>           silent, error, info, or debug
+  --version, -v                 Print the CLI version
+  --help, -h                    Print this help
+
+Commands:
+  generate-user-api-key         Generate a Discourse User API key
+`);
+}
+
 // CLI config schema - see also src/util/cli.ts for parseArgs
 const ProfileSchema = z
   .object({
@@ -185,6 +213,17 @@ async function main() {
     };
 
     await generateUserApiKey(options);
+    return;
+  }
+
+  if (shouldShowHelp(args)) {
+    printHelp();
+    return;
+  }
+
+  if (shouldShowVersion(args)) {
+    const version = await getPackageVersion();
+    process.stdout.write(`discourse-mcp ${version}\n`);
     return;
   }
 

--- a/src/test/transport.test.ts
+++ b/src/test/transport.test.ts
@@ -7,6 +7,24 @@ import path from 'node:path';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+async function runCli(args: string[]): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  const indexPath = path.resolve(__dirname, '../../dist/index.js');
+  const cliProcess = spawn('node', [indexPath, ...args], {
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+
+  let stdout = '';
+  let stderr = '';
+  cliProcess.stdout.on('data', (data) => { stdout += data; });
+  cliProcess.stderr.on('data', (data) => { stderr += data; });
+
+  return await new Promise((resolve) => {
+    cliProcess.on('exit', (code) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
 // Helper to get a free port
 async function getFreePort(): Promise<number> {
   return 3000 + Math.floor(Math.random() * 1000);
@@ -46,6 +64,23 @@ test('HTTP transport starts on specified port', async () => {
     serverProcess.kill('SIGTERM');
     await new Promise(resolve => setTimeout(resolve, 100));
   }
+});
+
+test('version flag prints version and exits', async () => {
+  const result = await runCli(['--version']);
+
+  assert.equal(result.code, 0);
+  assert.match(result.stdout, /^discourse-mcp \d+\.\d+\.\d+\n$/);
+  assert.equal(result.stderr, '');
+});
+
+test('help flag prints usage and exits', async () => {
+  const result = await runCli(['--help']);
+
+  assert.equal(result.code, 0);
+  assert.match(result.stdout, /Usage: discourse-mcp \[options\]/);
+  assert.match(result.stdout, /--version, -v/);
+  assert.equal(result.stderr, '');
 });
 
 test('HTTP transport health endpoint returns ok', async () => {


### PR DESCRIPTION
## What changed
- Added top-level `--version` / `-v` handling that prints the package version and exits.
- Added top-level `--help` / `-h` handling with concise CLI usage text.
- Added process-level regression tests for both flags.

## Why
The CLI currently treats metadata flags as normal server startup arguments. That makes simple package checks such as `discourse-mcp --version` and `discourse-mcp --help` start the MCP server instead of returning CLI metadata.

## Validation
- `npx --yes pnpm@10.14.0 build`
- `npx --yes pnpm@10.14.0 typecheck`
- `npx --yes pnpm@10.14.0 test`
- `npx --yes pnpm@10.14.0 lint`
- `node dist/index.js --version`
- `node dist/index.js --help`